### PR TITLE
Add more network-base commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,81 +1,282 @@
-# CONTRIBUTING
+# Contributing to Nadzoring
 
-# Contributing to nadzoring
+Thank you for your interest in contributing! Please read this guide carefully before submitting anything.
 
-We appreciate your interest in contributing to nadzoring! Please review these guidelines before submitting contributions.
+---
+
+## Table of Contents
+
+- [Contributing to Nadzoring](#contributing-to-nadzoring)
+  - [Table of Contents](#table-of-contents)
+  - [Code of Conduct](#code-of-conduct)
+  - [Reporting Issues](#reporting-issues)
+  - [Feature Requests](#feature-requests)
+  - [Development Setup](#development-setup)
+    - [Prerequisites](#prerequisites)
+    - [Installation](#installation)
+    - [Running Tests](#running-tests)
+    - [Linting \& Formatting](#linting--formatting)
+  - [Code Style](#code-style)
+    - [Python Version \& Typing](#python-version--typing)
+    - [Docstrings](#docstrings)
+    - [Keyword-Only Arguments](#keyword-only-arguments)
+    - [Dataclasses](#dataclasses)
+    - [Logging](#logging)
+    - [Error Handling](#error-handling)
+    - [`noqa` Comments](#noqa-comments)
+    - [CLI Commands](#cli-commands)
+    - [Module Structure](#module-structure)
+  - [Writing Tests](#writing-tests)
+  - [Pull Request Guidelines](#pull-request-guidelines)
+  - [Review Process](#review-process)
+  - [License](#license)
+
+---
 
 ## Code of Conduct
 
-All contributors must adhere to our Code of Conduct. Please read [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) before participating.
+All contributors must adhere to our [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). Please read it before participating.
 
-## Contribution Workflow
+---
 
-### 1. Reporting Issues
-- Check existing issues before creating new ones
-- Provide detailed reproduction steps
-- Include Python version and environment details
+## Reporting Issues
 
-### 2. Feature Requests
-- Explain the problem and proposed solution
-- Include use cases and potential benefits
-- Discuss alternatives considered
+- Search existing issues before opening a new one
+- Include your Python version, OS, and full error output
+- Provide minimal reproduction steps
 
-### 3. Code Contributions
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/your-feature`)
-3. Implement your changes
-4. Add tests covering all new functionality
-5. Ensure 100% test coverage
-6. Format code with Black (`black .`)
-7. Submit a pull request
+---
+
+## Feature Requests
+
+- Clearly describe the problem and your proposed solution
+- Include concrete use cases
+- Mention alternatives you considered
+
+---
 
 ## Development Setup
 
 ### Prerequisites
-- Python 3.12+
-- pip
-- uv (recommended)
+
+- Python **3.12+**
+- [`uv`](https://github.com/astral-sh/uv) (strongly recommended over pip)
 
 ### Installation
+
 ```bash
-git clone https://github.com/yourusername/nadzoring.git
+git clone https://github.com/alexeev-prog/nadzoring.git
 cd nadzoring
+
 uv venv
-source .venv/bin/activate  # Linux/macOS
-.venv\Scripts\activate     # Windows
+source .venv/bin/activate   # Linux / macOS
+.venv\Scripts\activate      # Windows
+
 uv sync
 ```
 
 ### Running Tests
+
 ```bash
 pytest --cov=nadzoring --cov-report=term-missing
 ```
 
-### Code Quality Checks
+100% test coverage is required for all new code.
+
+### Linting & Formatting
+
 ```bash
+# Lint with ruff
 ruff check src/nadzoring
 ```
 
-## Pull Request Guidelines
-1. Maintain 100% test coverage
-2. Update documentation if needed
-3. Keep commits atomic and well-described
-4. Reference related issues in PR description
-5. Ensure all CI checks pass
+Both must pass with no errors before submitting a PR. Zero-warning policy.
 
-## Code Standards
-- Follow PEP 8 style guide
-- Use type annotations for all functions
-- Document public APIs with docstrings
-- Keep functions small and focused
-- Prefer composition over inheritance
+---
+
+## Code Style
+
+The codebase follows strict conventions — study the existing source before writing new code.
+
+### Python Version & Typing
+
+- Target **Python 3.12+**
+- Use modern union syntax everywhere: `str | None`, not `Optional[str]`
+- Annotate **all** function parameters and return types, including `-> None`
+- Use built-in generics: `list[str]`, `dict[str, Any]`, `tuple[str, ...]` — not `List`, `Dict`, `Tuple` from `typing`
+
+```python
+# ✅ correct
+def resolve_hostname(hostname: str) -> str | None: ...
+
+# ❌ wrong
+from typing import Optional
+def resolve_hostname(hostname: str) -> Optional[str]: ...
+```
+
+### Docstrings
+
+All public functions, classes, and modules must have docstrings. Use Google-style with `Args:`, `Returns:`, and `Examples:` sections:
+
+```python
+def traceroute(
+    target: str,
+    *,
+    max_hops: int = 30,
+    timeout: float = 5.0,
+) -> list[TraceHop]:
+    """
+    Perform a traceroute to the specified target host.
+
+    Uses 'traceroute' (with 'tracepath' fallback) on Linux and 'tracert'
+    on Windows. Results include per-hop RTT measurements.
+
+    Args:
+        target: Hostname or IP address to trace.
+        max_hops: Maximum number of hops before stopping. Defaults to 30.
+        timeout: Per-hop timeout in seconds. Defaults to 5.0.
+
+    Returns:
+        List of TraceHop objects. Unreachable hops have None values for
+        host/ip and rtt_ms contains [None].
+
+    Examples:
+        >>> hops = traceroute("8.8.8.8", max_hops=10)
+        >>> hops[0].hop
+        1
+
+    """
+```
+
+### Keyword-Only Arguments
+
+Boolean flags and optional parameters must be keyword-only (after `*`):
+
+```python
+# ✅ correct
+def run(target: str, *, max_hops: int = 30, timeout: float = 5.0) -> list[TraceHop]: ...
+
+# ❌ wrong
+def run(target: str, max_hops: int = 30, timeout: float = 5.0) -> list[TraceHop]: ...
+```
+
+### Dataclasses
+
+Use `@dataclass` for structured data. Use `field(default_factory=...)` for mutable defaults:
+
+```python
+@dataclass
+class TraceHop:
+    """Represents a single hop in a traceroute."""
+
+    hop: int
+    host: str | None
+    ip: str | None
+    rtt_ms: list[float | None] = field(default_factory=list)
+```
+
+### Logging
+
+Use the project logger, never `print()` for internal output:
+
+```python
+from logging import Logger
+from nadzoring.logger import get_logger
+
+logger: Logger = get_logger(__name__)
+
+logger.warning("Unsupported OS for traceroute: %s", os_name)
+logger.exception("traceroute timed out for %s", target)
+```
+
+### Error Handling
+
+- Use `logger.exception(...)` inside `except` blocks — it automatically captures the traceback
+- Never swallow exceptions silently; always log or re-raise
+- Return empty collections (`[]`) rather than `None` for failed operations that return lists
+
+```python
+try:
+    raw = check_output("ip route", shell=True, stderr=PIPE).decode(errors="replace")
+except (CalledProcessError, FileNotFoundError):
+    logger.exception("Failed to retrieve routing table on Linux")
+    return []
+```
+
+### `noqa` Comments
+
+Suppress ruff rules only where unavoidable, always with an inline comment explaining the rule code:
+
+```python
+raw = check_output(  # noqa: S602
+    "ip route",     # noqa: S607
+    shell=True,
+    stderr=PIPE,
+)
+```
+
+### CLI Commands
+
+All CLI commands use the `@common_cli_options` decorator from `nadzoring.utils.decorators`. Commands return plain `list[dict]` — formatting and saving are handled by the decorator automatically:
+
+```python
+@dns.command(name="resolve")
+@common_cli_options(include_quiet=True)
+@click.argument("domains", nargs=-1, required=True)
+def resolve_command(
+    domains: tuple[str, ...],
+    *,
+    quiet: bool,
+) -> list[dict]:
+    """Resolve DNS records for one or more domains."""
+    ...
+    return results
+```
+
+- Never call `click.echo` for result data inside commands — only use it for progress hints to `err=True`
+- Use `tqdm` for progress bars; respect the `quiet` flag to suppress them
+- Pass `progress_callback` into library functions rather than coupling tqdm to business logic
+
+### Module Structure
+
+Each module must start with a one-line module docstring:
+
+```python
+"""DNS-related CLI commands."""
+```
+
+Group imports in standard order (stdlib → third-party → local), separated by blank lines. Use `from __future__ import annotations` only if needed for forward references — the project targets 3.12 where it is rarely necessary.
+
+---
+
+## Writing Tests
+
+- Cover all new functions and branches
+- Use `pytest`; no `unittest` classes
+- Mock external calls (DNS, subprocesses, network) — tests must not make real network requests
+- Name tests descriptively: `test_parse_linux_ip_route_timeout_hop`, not `test_parse`
+
+---
+
+## Pull Request Guidelines
+
+1. Fork the repository and create a branch: `git checkout -b feature/your-feature`
+2. Implement your changes following the code style above
+3. Add tests — 100% coverage required
+4. Run `ruff check` and `black .` — both must be clean
+5. Commit with clear, atomic messages: `fix: handle tracepath fallback on missing traceroute`
+6. Open a PR and reference any related issues
+
+---
 
 ## Review Process
-- Maintainers will review within 3 business days
-- Be responsive to feedback
-- Address requested changes promptly
-- Continuous integration must pass
+
+- Maintainers aim to review within **3 business days**
+- Be responsive to requested changes
+- All CI checks (lint, tests, coverage) must pass before merge
+
+---
 
 ## License
-By contributing, you agree your contributions will be licensed under the project's MIT license.
 
+By contributing, you agree your contributions will be licensed under the project's **GNU GPL v3** license.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     ·
     <a href="#-usage-examples">Basic Usage</a>
     ·
-    <a href="https://alexeev-prog.github.io/nadzoring/">Documentation</a>
+    <a href="https://alexeev-prog.github.io/nadzoring/v0.1.3">v0.1.3 Documentation</a>
     ·
     <a href="https://github.com/alexeev-prog/nadzoring/blob/main/LICENSE">License</a>
   </p>
@@ -41,7 +41,9 @@ Nadzoring (from Russian "надзор" - supervision/oversight + English "-ing" 
 ## 📋 Table of Contents
 - [Nadzoring](#nadzoring)
   - [📋 Table of Contents](#-table-of-contents)
-  - [🚀 Installation](#-installation)
+- [🚀 Getting Started](#-getting-started)
+    - [Prerequisites](#prerequisites)
+    - [Installation](#installation)
   - [💻 Usage](#-usage)
     - [Global Options](#global-options)
     - [DNS Commands](#dns-commands)
@@ -73,13 +75,30 @@ Nadzoring (from Russian "надзор" - supervision/oversight + English "-ing" 
     - [Complete Network Diagnostics](#complete-network-diagnostics)
     - [Automated Monitoring Script](#automated-monitoring-script)
     - [Quick Website Block Check](#quick-website-block-check)
-  - [Contributing](#contributing)
-  - [License \& Support](#license--support)
+  - [🤝 Contributing](#-contributing)
+  - [📚 Documentation](#-documentation)
+  - [⚖️ License \& Support](#️-license--support)
 
-## 🚀 Installation
+# 🚀 Getting Started
+
+### Prerequisites
+
+- Python 3.8+
+- pip
+- traceroute
+- whois
+- ip tools
+
+### Installation
 
 ```bash
 pip install nadzoring
+```
+
+Verify the installation:
+
+```bash
+nadzoring --help
 ```
 
 ## 💻 Usage
@@ -677,22 +696,43 @@ nadzoring dns compare example.com
 nadzoring dns poisoning example.com  # Most comprehensive block detection
 ```
 
-## Contributing
+## 🤝 Contributing
 
-We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. Key areas for contribution include:
+Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) before submitting a pull request.
+
+**Areas we'd love help with:**
 - Additional DNS record type support
 - New validation rules for health checks
 - CDN network database expansion
-- Performance optimization
+- Performance optimizations
 - Additional output formats
-- IDE integration plugins
+- IDE/editor integration plugins
 
-## License & Support
+**Workflow:**
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
 
-This project is licensed under **GNU GPL 3 License** - see [LICENSE](https://github.com/alexeev-prog/nadzoring/blob/main/LICENSE). For commercial support and enterprise features, contact [alexeev.dev@mail.ru](mailto:alexeev.dev@mail.ru).
+## 📚 Documentation
 
-[Explore Documentation](https://alexeev-prog.github.io/nadzoring) |
-[Report Issue](https://github.com/alexeev-prog/nadzoring/issues) |
+| Version | Link | Status |
+|---------|------|--------|
+| **main** | [Latest (development)](https://alexeev-prog.github.io/nadzoring/main) | 🟡 Development |
+| **v0.1.3** | [Stable release](https://alexeev-prog.github.io/nadzoring/v0.1.3) | 🟢 Stable |
+| v0.1.2 | [Previous stable](https://alexeev-prog.github.io/nadzoring/v0.1.2) | ⚪ Legacy |
+| v0.1.1 | [Legacy](https://alexeev-prog.github.io/nadzoring/v0.1.1) | ⚪ Legacy |
+| v0.1.0 | [Initial release](https://alexeev-prog.github.io/nadzoring/v0.1.0) | ⚪ Legacy |
+
+
+## ⚖️ License & Support
+
+This project is licensed under the **GNU GPL v3 License** — see [LICENSE](https://github.com/alexeev-prog/nadzoring/blob/main/LICENSE) for details.
+
+For commercial support or enterprise features, contact [alexeev.dev@mail.ru](mailto:alexeev.dev@mail.ru).
+
+[📖 Explore Docs](https://alexeev-prog.github.io/nadzoring) · [🐛 Report Issue](https://github.com/alexeev-prog/nadzoring/issues)
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,6 +2,8 @@ import os
 import sys
 from typing import Literal
 
+from sphinx_polyversion.api import load
+
 sys.path.insert(0, os.path.abspath("."))
 sys.path.insert(0, os.path.abspath(".."))
 sys.path.insert(0, os.path.abspath(os.path.join("..", "..")))
@@ -10,7 +12,6 @@ sys.path.insert(0, os.path.abspath("src"))
 sys.path.insert(0, os.path.abspath("../src/nadzoring"))
 sys.path.insert(0, os.path.abspath("src/nadzoring"))
 
-from sphinx_polyversion.api import load
 
 load(globals())
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,15 +3,9 @@
 Welcome to Nadzoring's documentation!
 ======================================
 
-**Nadzoring** (from Russian "надзор" - supervision/oversight + English "-ing" suffix) 
-is a FOSS (Free and Open Source Software) command-line tool for detecting website blocks, 
+**Nadzoring** (from Russian "надзор" - supervision/oversight + English "-ing" suffix)
+is a FOSS (Free and Open Source Software) command-line tool for detecting website blocks,
 monitoring service availability, and network analysis.
-
-Versions
--------------------
-
-* `Stable </nadzoring/>`_ - last stable release
-* `Latest </nadzoring/latest/>`_ - latest git-repo version
 
 .. toctree::
    :maxdepth: 2
@@ -21,10 +15,6 @@ Versions
    quickstart
    commands/index
    api/index
-
-.. note::
-   This documentation is for version |version|.
-   You are viewing the **{{ docs_type }}** version.
 
 Indices and tables
 ==================

--- a/src/nadzoring/commands/network_commands.py
+++ b/src/nadzoring/commands/network_commands.py
@@ -1,3 +1,5 @@
+"""Network base CLI commands."""
+
 from collections.abc import Callable
 from logging import Logger
 from typing import Any
@@ -6,7 +8,9 @@ import click
 from tqdm import tqdm
 
 from nadzoring.logger import get_logger
+from nadzoring.network_base.connections import ConnectionEntry, get_connections
 from nadzoring.network_base.geolocation_ip import geo_ip
+from nadzoring.network_base.http_ping import HttpPingResult, http_ping
 from nadzoring.network_base.ipv4_local_cli import get_local_ipv4
 from nadzoring.network_base.network_params import network_param
 from nadzoring.network_base.ping_address import ping_addr
@@ -16,6 +20,7 @@ from nadzoring.network_base.port_scanner import (
     get_ports_from_mode,
     scan_ports,
 )
+from nadzoring.network_base.route_table import RouteEntry, get_route_table
 from nadzoring.network_base.router_ip import (
     check_ipv4,
     check_ipv6,
@@ -23,6 +28,8 @@ from nadzoring.network_base.router_ip import (
     router_ip,
 )
 from nadzoring.network_base.service_on_port import get_service_on_port
+from nadzoring.network_base.traceroute import TraceHop, traceroute
+from nadzoring.network_base.whois_lookup import whois_lookup
 from nadzoring.utils.decorators import common_cli_options
 from nadzoring.utils.formatters import _format_scan_results
 
@@ -348,3 +355,298 @@ def port_service_command(
         pbar.close()
 
     return results
+
+
+@network_base.command(name="http-ping")
+@common_cli_options(include_quiet=True)
+@click.argument("urls", nargs=-1, required=True)
+@click.option(
+    "--timeout",
+    type=float,
+    default=10.0,
+    help="Request timeout in seconds",
+)
+@click.option(
+    "--no-ssl-verify",
+    is_flag=True,
+    help="Disable SSL certificate verification",
+)
+@click.option(
+    "--no-redirects",
+    is_flag=True,
+    help="Do not follow HTTP redirects",
+)
+@click.option(
+    "--show-headers",
+    is_flag=True,
+    help="Include response headers in output",
+)
+def http_ping_command(
+    urls: tuple[str, ...],
+    timeout: float,
+    *,
+    no_ssl_verify: bool,
+    no_redirects: bool,
+    show_headers: bool,
+    quiet: bool,
+) -> list[dict[str, Any]]:
+    """
+    Check HTTP/HTTPS response timing and headers for one or more URLs.
+
+    Measures DNS resolution time, time-to-first-byte (TTFB), total download
+    time, HTTP status code and optional response headers.
+    """
+    results: list[dict[str, Any]] = []
+    total = len(urls)
+
+    pbar = None if quiet else tqdm(total=total, desc="Probing URLs", unit="url")
+
+    for url in urls:
+        result: HttpPingResult = http_ping(
+            url,
+            timeout=timeout,
+            verify_ssl=not no_ssl_verify,
+            follow_redirects=not no_redirects,
+            include_headers=show_headers,
+        )
+
+        row: dict[str, Any] = {
+            "url": result.url,
+            "status": result.status_code or result.error or "error",
+            "dns_ms": result.dns_ms if result.dns_ms is not None else "n/a",
+            "ttfb_ms": result.ttfb_ms if result.ttfb_ms is not None else "n/a",
+            "total_ms": result.total_ms if result.total_ms is not None else "n/a",
+            "size_bytes": (
+                result.content_length if result.content_length is not None else "n/a"
+            ),
+        }
+
+        if result.final_url:
+            row["redirected_to"] = result.final_url
+
+        if show_headers and result.headers:
+            for header_key in (
+                "Content-Type",
+                "Server",
+                "Cache-Control",
+                "X-Powered-By",
+            ):
+                value = result.headers.get(header_key) or result.headers.get(
+                    header_key.lower()
+                )
+                if value:
+                    row[f"header_{header_key.lower().replace('-', '_')}"] = value
+
+        results.append(row)
+
+        if pbar:
+            pbar.set_description(f"Probing {url}")
+            pbar.update(1)
+
+    if pbar:
+        pbar.close()
+
+    return results
+
+
+@network_base.command(name="whois")
+@common_cli_options(include_quiet=True)
+@click.argument("targets", nargs=-1, required=True)
+def whois_command(
+    targets: tuple[str, ...],
+    *,
+    quiet: bool,
+) -> list[dict[str, Any]]:
+    """
+    Look up WHOIS registration info for one or more domains or IPs.
+
+    Requires the system 'whois' utility to be installed
+    (apt install whois / brew install whois).
+    """
+    results: list[dict[str, Any]] = []
+    total = len(targets)
+
+    pbar = None if quiet else tqdm(total=total, desc="Running WHOIS", unit="target")
+
+    for target in targets:
+        info = whois_lookup(target)
+        # Flatten to flat dict, drop None values for cleaner table output
+        row: dict[str, Any] = {k: v for k, v in info.items() if v is not None}
+        results.append(row)
+
+        if pbar:
+            pbar.set_description(f"WHOIS {target}")
+            pbar.update(1)
+
+    if pbar:
+        pbar.close()
+
+    return results
+
+
+@network_base.command(name="connections")
+@common_cli_options(include_quiet=True)
+@click.option(
+    "--protocol",
+    "-p",
+    type=click.Choice(["tcp", "udp", "all"], case_sensitive=False),
+    default="all",
+    help="Filter by protocol",
+)
+@click.option(
+    "--state",
+    "-s",
+    "state_filter",
+    default=None,
+    help="Filter by state substring, e.g. LISTEN or ESTABLISHED",
+)
+@click.option(
+    "--no-process",
+    is_flag=True,
+    help="Skip process/PID info (avoids permission errors)",
+)
+def connections_command(
+    protocol: str,
+    state_filter: str | None,
+    *,
+    no_process: bool,
+    quiet: bool,
+) -> list[dict[str, Any]]:
+    """
+    List active network connections (TCP/UDP).
+
+    Shows local/remote addresses, connection state and, where available,
+    the PID and process name. Analogous to 'ss' or 'netstat'.
+    """
+    entries: list[ConnectionEntry] = get_connections(
+        protocol=protocol,
+        state_filter=state_filter,
+        include_process=not no_process,
+    )
+
+    results: list[dict[str, Any]] = []
+    for entry in entries:
+        row: dict[str, Any] = {
+            "protocol": entry.protocol,
+            "local_address": entry.local_address,
+            "remote_address": entry.remote_address,
+            "state": entry.state or "—",
+        }
+        if entry.pid is not None:
+            row["pid"] = entry.pid
+        if entry.process is not None:
+            row["process"] = entry.process
+        results.append(row)
+
+    if not quiet and not results:
+        click.echo("No connections found matching the given filters.", err=True)
+
+    return results
+
+
+@network_base.command(name="traceroute")
+@common_cli_options(include_quiet=True)
+@click.argument("targets", nargs=-1, required=True)
+@click.option(
+    "--max-hops",
+    type=int,
+    default=30,
+    help="Maximum number of hops",
+)
+@click.option(
+    "--timeout",
+    type=float,
+    default=2.0,
+    help="Per-hop timeout in seconds (default: 2)",
+)
+@click.option(
+    "--sudo",
+    "use_sudo",
+    is_flag=True,
+    help="Run traceroute with sudo (required on some Linux systems)",
+)
+def traceroute_command(
+    targets: tuple[str, ...],
+    max_hops: int,
+    timeout: float,
+    *,
+    use_sudo: bool,
+    quiet: bool,
+) -> list[dict[str, Any]]:
+    """
+    Trace the network path to one or more hosts.
+
+    Uses 'traceroute' (Linux) or 'tracert' (Windows). On Linux, raw-socket
+    access is needed: run with --sudo, as root, or grant the capability with
+    'sudo setcap cap_net_raw+ep $(which traceroute)'.
+    tracepath is tried automatically as a root-free fallback.
+    """
+    results: list[dict[str, Any]] = []
+    total = len(targets)
+
+    pbar = None if quiet else tqdm(total=total, desc="Tracing routes", unit="target")
+
+    for target in targets:
+        if not quiet:
+            click.echo(f"\nTraceroute to {target}:", err=True)
+
+        hops: list[TraceHop] = traceroute(
+            target,
+            max_hops=max_hops,
+            per_hop_timeout=timeout,
+            use_sudo=use_sudo,
+        )
+
+        for hop in hops:
+            rtt_values = [f"{r:.1f} ms" if r is not None else "*" for r in hop.rtt_ms]
+            results.append(
+                {
+                    "target": target,
+                    "hop": hop.hop,
+                    "host": hop.host or "*",
+                    "ip": hop.ip or "*",
+                    "rtt": " / ".join(rtt_values),
+                }
+            )
+
+        if not hops and not quiet:
+            click.echo(f"No hops returned for {target}.", err=True)
+
+        if pbar:
+            pbar.set_description(f"Tracing {target}")
+            pbar.update(1)
+
+    if pbar:
+        pbar.close()
+
+    return results
+
+
+@network_base.command(name="route")
+@common_cli_options(include_quiet=True)
+def route_command(*, quiet: bool = False) -> list[dict[str, Any]]:
+    """
+    Display the system IP routing table.
+
+    Uses 'ip route' on Linux and 'route PRINT' on Windows.
+    """
+    entries: list[RouteEntry] = get_route_table()
+
+    if not entries and not quiet:
+        click.echo(
+            "Could not retrieve routing table. "
+            "Check that 'ip' (Linux) or 'route' (Windows) is available.",
+            err=True,
+        )
+        return []
+
+    return [
+        {
+            "destination": entry.destination,
+            "gateway": entry.gateway,
+            "netmask": entry.netmask or "—",
+            "interface": entry.interface or "—",
+            "metric": entry.metric or "—",
+        }
+        for entry in entries
+    ]

--- a/src/nadzoring/network_base/connections.py
+++ b/src/nadzoring/network_base/connections.py
@@ -1,0 +1,231 @@
+"""Active network connections listing (netstat/ss equivalent)."""
+
+import contextlib
+import re
+from dataclasses import dataclass
+from logging import Logger
+from platform import system
+from subprocess import PIPE, CalledProcessError, check_output
+
+from nadzoring.logger import get_logger
+
+logger: Logger = get_logger(__name__)
+
+
+@dataclass
+class ConnectionEntry:
+    """Represents a single active network connection."""
+
+    protocol: str
+    local_address: str
+    remote_address: str
+    state: str
+    pid: str | None = None
+    process: str | None = None
+
+
+def _parse_ss_output(raw: str) -> list[ConnectionEntry]:
+    """
+    Parse the output of the Linux 'ss' command.
+
+    Args:
+        raw: Raw text output from ss command.
+
+    Returns:
+        List of parsed ConnectionEntry objects.
+
+    """
+    entries: list[ConnectionEntry] = []
+    lines = raw.strip().splitlines()
+    if len(lines) < 2:  # skip if only header or empty
+        return entries
+
+    for line in lines[1:]:
+        parts = line.split()
+        if len(parts) < 5:
+            continue
+
+        proto = parts[0]
+        state = parts[1]
+        local = parts[4] if len(parts) > 4 else ""
+        remote = parts[5] if len(parts) > 5 else ""
+
+        pid: str | None = None
+        process: str | None = None
+        for part in parts[6:]:
+            if "pid=" in part:
+                with contextlib.suppress(IndexError):
+                    pid = part.split("pid=")[1].split(",")[0].rstrip(")")
+            if part.startswith('users:(("'):
+                proc_match = re.search(r'users:\(\("([^"]+)"', part)
+                if proc_match:
+                    process = proc_match.group(1)
+
+        entries.append(
+            ConnectionEntry(
+                protocol=proto,
+                local_address=local,
+                remote_address=remote,
+                state=state,
+                pid=pid,
+                process=process,
+            )
+        )
+
+    return entries
+
+
+def _parse_netstat_output(raw: str) -> list[ConnectionEntry]:
+    """
+    Parse the output of the Windows 'netstat -ano' command.
+
+    Args:
+        raw: Raw text output from netstat -ano.
+
+    Returns:
+        List of parsed ConnectionEntry objects.
+
+    """
+    entries: list[ConnectionEntry] = []
+
+    for line in raw.splitlines():
+        parts = line.split()
+        if not parts or parts[0] not in ("TCP", "UDP"):
+            continue
+
+        proto = parts[0]
+        if proto == "TCP" and len(parts) >= 5:
+            entries.append(
+                ConnectionEntry(
+                    protocol=proto,
+                    local_address=parts[1],
+                    remote_address=parts[2],
+                    state=parts[3],
+                    pid=parts[4],
+                )
+            )
+        elif proto == "UDP" and len(parts) >= 4:
+            entries.append(
+                ConnectionEntry(
+                    protocol=proto,
+                    local_address=parts[1],
+                    remote_address=parts[2],
+                    state="",
+                    pid=parts[3],
+                )
+            )
+
+    return entries
+
+
+def _filter_entries(
+    entries: list[ConnectionEntry],
+    *,
+    protocol: str,
+    state_filter: str | None,
+) -> list[ConnectionEntry]:
+    """
+    Filter connection entries by protocol and state.
+
+    Args:
+        entries: List of connection entries to filter.
+        protocol: Protocol filter - 'tcp', 'udp', or 'all'.
+        state_filter: Optional state substring filter (case-insensitive).
+
+    Returns:
+        Filtered list of ConnectionEntry objects.
+
+    """
+    if protocol != "all":
+        entries = [e for e in entries if e.protocol.lower() == protocol.lower()]
+    if state_filter:
+        entries = [e for e in entries if state_filter.upper() in e.state.upper()]
+    return entries
+
+
+def _get_linux_connections(
+    *,
+    protocol: str,
+    state_filter: str | None,
+    include_process: bool,
+) -> list[ConnectionEntry]:
+    """Get active connections on Linux using ss."""
+    flags = "-tuna" + ("p" if include_process else "")
+    try:
+        raw = check_output(  # noqa: S602
+            f"ss {flags}",
+            shell=True,
+            stderr=PIPE,
+        ).decode(errors="replace")
+    except (CalledProcessError, FileNotFoundError):
+        logger.exception("Failed to run ss on Linux")
+        return []
+
+    entries = _parse_ss_output(raw)
+    return _filter_entries(entries, protocol=protocol, state_filter=state_filter)
+
+
+def _get_windows_connections(
+    *,
+    protocol: str,
+    state_filter: str | None,
+) -> list[ConnectionEntry]:
+    """Get active connections on Windows using netstat."""
+    try:
+        raw = check_output(  # noqa: S602
+            "netstat -ano",  # noqa: S607
+            shell=True,
+            stderr=PIPE,
+        ).decode("cp866", errors="replace")
+    except (CalledProcessError, FileNotFoundError):
+        logger.exception("Failed to run netstat on Windows")
+        return []
+
+    entries = _parse_netstat_output(raw)
+    return _filter_entries(entries, protocol=protocol, state_filter=state_filter)
+
+
+def get_connections(
+    *,
+    protocol: str = "all",
+    state_filter: str | None = None,
+    include_process: bool = True,
+) -> list[ConnectionEntry]:
+    """
+    List active network connections on the current system.
+
+    On Linux, uses 'ss'. On Windows, uses 'netstat -ano'.
+    Process information may require elevated permissions on some systems.
+
+    Args:
+        protocol: Protocol to filter by - 'tcp', 'udp', or 'all'. Defaults to 'all'.
+        state_filter: Case-insensitive state substring filter, e.g. 'LISTEN' or
+            'ESTABLISHED'. Defaults to None (no filter).
+        include_process: Whether to include PID/process name (may need root on
+            Linux). Defaults to True.
+
+    Returns:
+        List of ConnectionEntry objects, one per active connection.
+
+    Examples:
+        >>> listening = get_connections(state_filter="LISTEN")
+        >>> len(listening) > 0
+        True
+
+    """
+    os_name = system()
+
+    if os_name == "Linux":
+        return _get_linux_connections(
+            protocol=protocol,
+            state_filter=state_filter,
+            include_process=include_process,
+        )
+    if os_name == "Windows":
+        return _get_windows_connections(
+            protocol=protocol,
+            state_filter=state_filter,
+        )
+
+    logger.warning("Unsupported OS for connections listing: %s", os_name)
+    return []

--- a/src/nadzoring/network_base/http_ping.py
+++ b/src/nadzoring/network_base/http_ping.py
@@ -1,0 +1,123 @@
+"""HTTP/HTTPS response timing and diagnostics."""
+
+import socket
+import time
+from dataclasses import dataclass, field
+from urllib.parse import urlparse
+
+from requests import Session
+from requests.exceptions import RequestException
+
+
+@dataclass
+class HttpPingResult:
+    """Result of a single HTTP ping operation."""
+
+    url: str
+    final_url: str | None
+    status_code: int | None
+    dns_ms: float | None
+    ttfb_ms: float | None
+    total_ms: float | None
+    content_length: int | None
+    headers: dict[str, str] = field(default_factory=dict)
+    error: str | None = None
+
+
+def _measure_dns(hostname: str) -> float | None:
+    """
+    Measure DNS resolution time in milliseconds.
+
+    Args:
+        hostname: Hostname to resolve.
+
+    Returns:
+        Resolution time in milliseconds, or None if resolution failed.
+
+    """
+    start = time.perf_counter()
+    try:
+        socket.gethostbyname(hostname)
+    except socket.gaierror:
+        return None
+    return round((time.perf_counter() - start) * 1000, 2)
+
+
+def http_ping(
+    url: str,
+    *,
+    timeout: float = 10.0,
+    verify_ssl: bool = True,
+    follow_redirects: bool = True,
+    include_headers: bool = True,
+) -> HttpPingResult:
+    """
+    Perform an HTTP request and collect detailed timing metrics.
+
+    Measures DNS resolution time separately, then tracks time-to-first-byte
+    (TTFB) and total download duration using streaming response mode.
+
+    Args:
+        url: Target URL to probe. HTTP scheme is added if missing.
+        timeout: Request timeout in seconds. Defaults to 10.0.
+        verify_ssl: Whether to verify SSL certificates. Defaults to True.
+        follow_redirects: Whether to follow HTTP redirects. Defaults to True.
+        include_headers: Whether to include response headers. Defaults to True.
+
+    Returns:
+        HttpPingResult with timing breakdown and response metadata.
+
+    Examples:
+        >>> result = http_ping("https://example.com")
+        >>> result.status_code
+        200
+
+    """
+    if not url.startswith(("http://", "https://")):
+        url = f"http://{url}"
+
+    parsed = urlparse(url)
+    hostname = parsed.hostname or ""
+
+    dns_ms = _measure_dns(hostname) if hostname else None
+
+    session = Session()
+    try:
+        start = time.perf_counter()
+        with session.get(
+            url,
+            stream=True,
+            timeout=timeout,
+            verify=verify_ssl,
+            allow_redirects=follow_redirects,
+        ) as response:
+            ttfb_ms = round((time.perf_counter() - start) * 1000, 2)
+            content = response.content
+            total_ms = round((time.perf_counter() - start) * 1000, 2)
+
+        headers = dict(response.headers) if include_headers else {}
+        final = str(response.url)
+
+        return HttpPingResult(
+            url=url,
+            final_url=final if final != url else None,
+            status_code=response.status_code,
+            dns_ms=dns_ms,
+            ttfb_ms=ttfb_ms,
+            total_ms=total_ms,
+            content_length=len(content),
+            headers=headers,
+        )
+    except RequestException as exc:
+        return HttpPingResult(
+            url=url,
+            final_url=None,
+            status_code=None,
+            dns_ms=dns_ms,
+            ttfb_ms=None,
+            total_ms=None,
+            content_length=None,
+            error=str(exc),
+        )
+    finally:
+        session.close()

--- a/src/nadzoring/network_base/route_table.py
+++ b/src/nadzoring/network_base/route_table.py
@@ -1,0 +1,174 @@
+"""System routing table retrieval and parsing."""
+
+from dataclasses import dataclass
+from logging import Logger
+from platform import system
+from subprocess import PIPE, CalledProcessError, check_output
+
+from nadzoring.logger import get_logger
+
+logger: Logger = get_logger(__name__)
+
+
+@dataclass
+class RouteEntry:
+    """Represents a single entry in the system routing table."""
+
+    destination: str
+    gateway: str
+    netmask: str | None
+    interface: str | None
+    metric: str | None
+    flags: str | None
+
+
+def _parse_linux_ip_route(raw: str) -> list[RouteEntry]:
+    """
+    Parse the output of 'ip route' on Linux.
+
+    Each line is of the form:
+        <destination> [via <gateway>] dev <iface> [metric <n>] ...
+
+    Args:
+        raw: Raw text output from ip route.
+
+    Returns:
+        List of RouteEntry objects.
+
+    """
+    entries: list[RouteEntry] = []
+
+    for line in raw.strip().splitlines():
+        parts = line.split()
+        if not parts:
+            continue
+
+        destination = parts[0]
+        gateway: str = "0.0.0.0"  # noqa: S104
+        interface: str | None = None
+        metric: str | None = None
+
+        for i, part in enumerate(parts):
+            if part == "via" and i + 1 < len(parts):
+                gateway = parts[i + 1]
+            elif part == "dev" and i + 1 < len(parts):
+                interface = parts[i + 1]
+            elif part == "metric" and i + 1 < len(parts):
+                metric = parts[i + 1]
+
+        entries.append(
+            RouteEntry(
+                destination=destination,
+                gateway=gateway,
+                netmask=None,
+                interface=interface,
+                metric=metric,
+                flags=None,
+            )
+        )
+
+    return entries
+
+
+def _parse_windows_route_print(raw: str) -> list[RouteEntry]:
+    """
+    Parse the output of 'route PRINT' on Windows.
+
+    Extracts IPv4 routes from the Active Routes section.
+
+    Args:
+        raw: Raw text output from route PRINT.
+
+    Returns:
+        List of RouteEntry objects.
+
+    """
+    entries: list[RouteEntry] = []
+    in_active_section = False
+
+    for line in raw.splitlines():
+        stripped = line.strip()
+
+        if "Active Routes:" in stripped:
+            in_active_section = True
+            continue
+        if "Persistent Routes:" in stripped or "IPv6 Route Table" in stripped:
+            in_active_section = False
+            continue
+        if not in_active_section or not stripped:
+            continue
+        if "Network Destination" in stripped or stripped.startswith("="):
+            continue
+
+        parts = stripped.split()
+        if len(parts) >= 5:
+            entries.append(
+                RouteEntry(
+                    destination=parts[0],
+                    gateway=parts[2],
+                    netmask=parts[1],
+                    interface=parts[3],
+                    metric=parts[4],
+                    flags=None,
+                )
+            )
+
+    return entries
+
+
+def _get_linux_routes() -> list[RouteEntry]:
+    """Retrieve routing table on Linux using 'ip route'."""
+    try:
+        raw = check_output(  # noqa: S602
+            "ip route",  # noqa: S607
+            shell=True,
+            stderr=PIPE,
+        ).decode(errors="replace")
+    except (CalledProcessError, FileNotFoundError):
+        logger.exception("Failed to retrieve routing table on Linux")
+        return []
+
+    return _parse_linux_ip_route(raw)
+
+
+def _get_windows_routes() -> list[RouteEntry]:
+    """Retrieve routing table on Windows using 'route PRINT'."""
+    try:
+        raw = check_output(  # noqa: S602
+            "route PRINT",  # noqa: S607
+            shell=True,
+            stderr=PIPE,
+        ).decode("cp866", errors="replace")
+    except (CalledProcessError, FileNotFoundError):
+        logger.exception("Failed to retrieve routing table on Windows")
+        return []
+
+    return _parse_windows_route_print(raw)
+
+
+def get_route_table() -> list[RouteEntry]:
+    """
+    Retrieve the system's IP routing table.
+
+    Uses 'ip route' on Linux and 'route PRINT' on Windows to fetch
+    the current routing table and returns it as structured data.
+
+    Returns:
+        List of RouteEntry objects representing all routing table entries,
+        or an empty list if the OS is unsupported or the command fails.
+
+    Examples:
+        >>> routes = get_route_table()
+        >>> any(r.destination == "default" for r in routes)
+        True
+
+    """
+    os_name = system()
+
+    if os_name == "Linux":
+        return _get_linux_routes()
+    if os_name == "Windows":
+        return _get_windows_routes()
+
+    logger.warning("Unsupported OS for route table: %s", os_name)
+    return []

--- a/src/nadzoring/network_base/traceroute.py
+++ b/src/nadzoring/network_base/traceroute.py
@@ -1,0 +1,364 @@
+"""Traceroute implementation using system commands."""
+
+import re
+from dataclasses import dataclass, field
+from logging import Logger
+from platform import system
+from subprocess import PIPE, CalledProcessError, Popen, TimeoutExpired
+
+from nadzoring.logger import get_logger
+
+logger: Logger = get_logger(__name__)
+
+_PERMISSION_DENIED_HINTS = ("operation not permitted", "permission denied")
+
+
+@dataclass
+class TraceHop:
+    """Represents a single hop in a traceroute."""
+
+    hop: int
+    host: str | None
+    ip: str | None
+    rtt_ms: list[float | None] = field(default_factory=list)
+
+
+def _parse_linux_traceroute(raw: str) -> list[TraceHop]:
+    """
+    Parse the output of the Linux traceroute command.
+
+    Args:
+        raw: Raw text output from traceroute.
+
+    Returns:
+        List of TraceHop objects.
+
+    """
+    hops: list[TraceHop] = []
+
+    for line in raw.strip().splitlines():
+        line = line.strip()  # noqa: PLW2901
+        if not line:
+            continue
+
+        match = re.match(r"^\s*(\d+)\s+(.+)$", line)
+        if not match:
+            continue
+
+        hop_num = int(match.group(1))
+        rest = match.group(2).strip()
+
+        # Timeout-only hop
+        if re.match(r"^(\*\s*)+$", rest):
+            hops.append(TraceHop(hop=hop_num, host=None, ip=None, rtt_ms=[None]))
+            continue
+
+        host: str | None = None
+        ip: str | None = None
+        rtts: list[float | None] = []
+
+        host_match = re.match(r"^([^\s(]+)\s*\(([^)]+)\)\s*(.*)", rest)
+        if host_match:
+            host = host_match.group(1)
+            ip = host_match.group(2)
+            rtt_str = host_match.group(3)
+        else:
+            parts = rest.split()
+            if parts:
+                ip = parts[0]
+                host = parts[0]
+                rtt_str = " ".join(parts[1:])
+            else:
+                rtt_str = ""
+
+        for rtt_match in re.finditer(r"([\d.]+)\s*ms", rtt_str):
+            try:
+                rtts.append(float(rtt_match.group(1)))
+            except ValueError:
+                rtts.append(None)
+
+        hops.append(
+            TraceHop(
+                hop=hop_num,
+                host=host,
+                ip=ip,
+                rtt_ms=rtts or [None],
+            )
+        )
+
+    return hops
+
+
+def _parse_windows_tracert(raw: str) -> list[TraceHop]:
+    """
+    Parse the output of the Windows tracert command.
+
+    Args:
+        raw: Raw text output from tracert.
+
+    Returns:
+        List of TraceHop objects.
+
+    """
+    hops: list[TraceHop] = []
+
+    for line in raw.strip().splitlines():
+        line = line.strip()  # noqa: PLW2901
+        match = re.match(r"^\s*(\d+)\s+(.+)$", line)
+        if not match:
+            continue
+
+        hop_num = int(match.group(1))
+        rest = match.group(2).strip()
+
+        # All-timeout hop
+        if re.match(r"^(\*\s*)+$", rest):
+            hops.append(TraceHop(hop=hop_num, host=None, ip=None, rtt_ms=[None]))
+            continue
+
+        rtts: list[float | None] = []
+        for rtt_match in re.finditer(r"(\d+)\s*ms", rest):
+            try:
+                rtts.append(float(rtt_match.group(1)))
+            except ValueError:
+                rtts.append(None)
+
+        ip_match = re.search(r"([\d.]+)\s*$", rest)
+        ip = ip_match.group(1) if ip_match else None
+
+        host_match = re.search(r"([a-zA-Z][^\s]+)\s+[\d.]+\s*$", rest)
+        host = host_match.group(1) if host_match else ip
+
+        hops.append(
+            TraceHop(
+                hop=hop_num,
+                host=host,
+                ip=ip,
+                rtt_ms=rtts or [None],
+            )
+        )
+
+    return hops
+
+
+def _stream_process(cmd: str, *, wall_timeout: float) -> tuple[str, str]:
+    """
+    Run a shell command and collect its output, returning partial output on timeout.
+
+    Using ``Popen`` instead of ``check_output`` lets us collect whatever
+    stdout was written before the wall-clock deadline fires.
+
+    Args:
+        cmd: Shell command to execute.
+        wall_timeout: Maximum total wall-clock seconds to wait.
+
+    Returns:
+        Tuple of (stdout_text, stderr_text). stdout_text may be partial if
+        the process was still running when the timeout fired.
+
+    """
+    with Popen(  # noqa: S602
+        cmd,
+        shell=True,
+        stdout=PIPE,
+        stderr=PIPE,
+        text=True,
+        errors="replace",
+    ) as proc:
+        try:
+            stdout, stderr = proc.communicate(timeout=wall_timeout)
+        except TimeoutExpired:
+            proc.kill()
+            stdout, stderr = proc.communicate()
+            logger.warning(
+                "Command timed out after %.0f s, returning partial output", wall_timeout
+            )
+
+    return stdout or "", stderr or ""
+
+
+def _is_permission_error(stderr: str) -> bool:
+    """Return True if stderr indicates a permissions problem."""
+    return any(hint in stderr.lower() for hint in _PERMISSION_DENIED_HINTS)
+
+
+def _run_linux_traceroute(
+    target: str,
+    *,
+    max_hops: int,
+    per_hop_timeout: float,
+    use_sudo: bool,
+) -> list[TraceHop]:
+    """
+    Execute traceroute on Linux, falling back to tracepath if unavailable.
+
+    Args:
+        target: Hostname or IP address.
+        max_hops: Maximum number of hops.
+        per_hop_timeout: Per-hop timeout passed to traceroute -w.
+        use_sudo: Prefix the command with sudo.
+
+    Returns:
+        List of TraceHop objects (may be partial on timeout).
+
+    """
+    timeout_int = max(1, int(per_hop_timeout))
+    # 3 probes per hop + small fixed margin
+    wall_timeout = max_hops * per_hop_timeout * 3 + 5
+
+    prefix = "sudo " if use_sudo else ""
+    cmd = f"{prefix}traceroute -m {max_hops} -w {timeout_int} {target}"
+
+    stdout, stderr = _stream_process(cmd, wall_timeout=wall_timeout)
+
+    if not stdout and _is_permission_error(stderr):
+        logger.error(
+            "traceroute requires elevated privileges for %s. "
+            "Re-run with --sudo or execute as root.",
+            target,
+        )
+        return []
+
+    if stdout:
+        return _parse_linux_traceroute(stdout)
+
+    # Binary not found — try tracepath (no root required)
+    if "not found" in stderr.lower() or "no such file" in stderr.lower():
+        logger.warning("traceroute not found, trying tracepath")
+        return _run_tracepath(
+            target, max_hops=max_hops, per_hop_timeout=per_hop_timeout
+        )
+
+    logger.warning(
+        "traceroute produced no output for %s; stderr: %s", target, stderr.strip()
+    )
+    return []
+
+
+def _run_tracepath(
+    target: str,
+    *,
+    max_hops: int,
+    per_hop_timeout: float,
+) -> list[TraceHop]:
+    """
+    Fallback to tracepath (does not require root on Linux).
+
+    Args:
+        target: Hostname or IP address.
+        max_hops: Maximum number of hops.
+        per_hop_timeout: Used to calculate the wall-clock budget.
+
+    Returns:
+        List of TraceHop objects (may be partial on timeout).
+
+    """
+    wall_timeout = max_hops * per_hop_timeout * 3 + 5
+    stdout, stderr = _stream_process(
+        f"tracepath -m {max_hops} -n {target}",
+        wall_timeout=wall_timeout,
+    )
+
+    if stdout:
+        return _parse_linux_traceroute(stdout)
+
+    logger.error("tracepath also failed for %s: %s", target, stderr.strip())
+    return []
+
+
+def _run_windows_tracert(
+    target: str,
+    *,
+    max_hops: int,
+    per_hop_timeout: float,
+) -> list[TraceHop]:
+    """
+    Execute tracert on Windows.
+
+    Args:
+        target: Hostname or IP address.
+        max_hops: Maximum number of hops.
+        per_hop_timeout: Used to calculate the wall-clock budget.
+
+    Returns:
+        List of TraceHop objects (may be partial on timeout).
+
+    """
+    wall_timeout = max_hops * per_hop_timeout * 3 + 5
+    cmd = f"tracert -h {max_hops} {target}"
+
+    try:
+        with Popen(  # noqa: S602
+            cmd,
+            shell=True,
+            stdout=PIPE,
+            stderr=PIPE,
+        ) as proc:
+            try:
+                stdout_b, _ = proc.communicate(timeout=wall_timeout)
+            except TimeoutExpired:
+                proc.kill()
+                stdout_b, _ = proc.communicate()
+    except (CalledProcessError, FileNotFoundError):
+        logger.exception("Failed to run tracert for %s", target)
+        return []
+
+    raw = stdout_b.decode("cp866", errors="replace") if stdout_b else ""
+    return _parse_windows_tracert(raw)
+
+
+def traceroute(
+    target: str,
+    *,
+    max_hops: int = 30,
+    per_hop_timeout: float = 2.0,
+    use_sudo: bool = False,
+) -> list[TraceHop]:
+    """
+    Perform a traceroute to the specified target host.
+
+    Uses 'traceroute' (with 'tracepath' fallback) on Linux and 'tracert'
+    on Windows. Partial results are returned if the overall timeout fires
+    before the trace completes.
+
+    On Linux, ``traceroute`` requires raw-socket privileges.  Either run the
+    process as root, pass ``use_sudo=True``, or grant the capability:
+    ``sudo setcap cap_net_raw+ep $(which traceroute)``.
+    ``tracepath`` is tried automatically as a root-free fallback.
+
+    Args:
+        target: Hostname or IP address to trace.
+        max_hops: Maximum number of hops before stopping. Defaults to 30.
+        per_hop_timeout: Per-hop timeout in seconds passed to the underlying
+            tool. The overall wall-clock budget is ``max_hops * per_hop_timeout
+            * 3 + 5``. Defaults to 2.0.
+        use_sudo: Prefix the command with ``sudo`` on Linux. Defaults to False.
+
+    Returns:
+        List of TraceHop objects. Unreachable hops have None for host/ip and
+        rtt_ms contains [None].
+
+    Examples:
+        >>> hops = traceroute("8.8.8.8", max_hops=5)
+        >>> hops[0].hop
+        1
+
+    """
+    os_name = system()
+
+    if os_name == "Linux":
+        return _run_linux_traceroute(
+            target,
+            max_hops=max_hops,
+            per_hop_timeout=per_hop_timeout,
+            use_sudo=use_sudo,
+        )
+    if os_name == "Windows":
+        return _run_windows_tracert(
+            target,
+            max_hops=max_hops,
+            per_hop_timeout=per_hop_timeout,
+        )
+
+    logger.warning("Unsupported OS for traceroute: %s", os_name)
+    return []

--- a/src/nadzoring/network_base/whois_lookup.py
+++ b/src/nadzoring/network_base/whois_lookup.py
@@ -1,0 +1,134 @@
+"""WHOIS information lookup for domains and IP addresses."""
+
+from ipaddress import ip_address
+from logging import Logger
+from platform import system
+from subprocess import PIPE, CalledProcessError, check_output
+
+from nadzoring.logger import get_logger
+
+logger: Logger = get_logger(__name__)
+
+_WHOIS_FIELD_MAP: dict[str, list[str]] = {
+    "registrar": ["Registrar:", "registrar:"],
+    "creation_date": ["Creation Date:", "created:", "Created:"],
+    "expiry_date": [
+        "Registry Expiry Date:",
+        "Expiry Date:",
+        "expires:",
+        "Expiration Date:",
+    ],
+    "updated_date": ["Updated Date:", "last-modified:", "Last Modified:"],
+    "name_servers": ["Name Server:", "nserver:"],
+    "status": ["Domain Status:", "status:"],
+    "registrant_org": ["Registrant Organization:", "org:", "Organisation:"],
+    "country": ["Registrant Country:", "country:"],
+    "abuse_email": ["Abuse Contact Email:", "abuse-mailbox:"],
+    "netrange": ["NetRange:", "inetnum:"],
+    "org_name": ["OrgName:", "org-name:", "OrgName:"],
+    "cidr": ["CIDR:"],
+    "asn": ["OriginAS:", "origin:"],
+}
+
+
+def _is_ip(target: str) -> bool:
+    """Return True if target is a valid IP address."""
+    try:
+        ip_address(target)
+    except ValueError:
+        return False
+    return True
+
+
+def _run_whois_command(target: str) -> str | None:
+    """
+    Execute the system whois command for the given target.
+
+    Args:
+        target: Domain or IP address to query.
+
+    Returns:
+        Raw WHOIS output string, or None if the command failed.
+
+    """
+    os_name = system()
+    encoding = "cp866" if os_name == "Windows" else "utf-8"
+
+    try:
+        return check_output(  # noqa: S602
+            f"whois {target}",
+            shell=True,
+            stderr=PIPE,
+            timeout=15,
+        ).decode(encoding, errors="replace")
+    except (CalledProcessError, FileNotFoundError, TimeoutError):
+        logger.exception("Failed to run whois for %s", target)
+        return None
+
+
+def _parse_whois_output(raw: str) -> dict[str, str | None]:
+    """
+    Parse raw WHOIS text into a structured dictionary.
+
+    Extracts known fields from the WHOIS output by matching line prefixes
+    against a predefined field mapping. Only the first occurrence of each
+    field is captured.
+
+    Args:
+        raw: Raw text output from the whois command.
+
+    Returns:
+        Dictionary mapping field names to extracted values.
+
+    """
+    result: dict[str, str | None] = dict.fromkeys(_WHOIS_FIELD_MAP)
+
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith(("%", "#")):
+            continue
+        for field_key, prefixes in _WHOIS_FIELD_MAP.items():
+            if result[field_key] is not None:
+                continue
+            for prefix in prefixes:
+                if stripped.lower().startswith(prefix.lower()):
+                    value = stripped[len(prefix) :].strip()
+                    if value:
+                        result[field_key] = value
+                        break
+
+    return result
+
+
+def whois_lookup(target: str) -> dict[str, str | None]:
+    """
+    Perform a WHOIS lookup for a domain or IP address.
+
+    Uses the system whois command to retrieve ownership and registration
+    information, then parses the output into a structured dictionary.
+
+    Args:
+        target: Domain name or IP address to look up.
+
+    Returns:
+        Dictionary with parsed WHOIS fields. Contains an 'error' key
+        if the lookup failed (e.g., whois is not installed).
+
+    Examples:
+        >>> result = whois_lookup("example.com")
+        >>> result["registrar"]
+        'RESERVED-Internet Assigned Numbers Authority'
+
+    """
+    raw = _run_whois_command(target)
+    if raw is None:
+        return {
+            "target": target,
+            "type": "ip" if _is_ip(target) else "domain",
+            "error": "WHOIS lookup failed. Ensure 'whois' is installed.",
+        }
+
+    parsed = _parse_whois_output(raw)
+    parsed["target"] = target
+    parsed["type"] = "ip" if _is_ip(target) else "domain"
+    return parsed


### PR DESCRIPTION
This PR significantly expands the network diagnostic capabilities of the CLI by adding five new commands to the `network-base` group, along with comprehensive documentation updates.

**New Commands Added:**

• `connections` – Lists active TCP/UDP connections (like netstat/ss). Shows local/remote addresses, connection state, and optionally includes PID/process name. Example: `nadzoring network-base connections --protocol tcp --state LISTEN`

• `http-ping` – Measures HTTP/HTTPS response timing with detailed breakdown: DNS resolution time, time-to-first-byte (TTFB), total download time, status code, and optional headers. Example: `nadzoring network-base http-ping https://example.com --show-headers`

• `route` – Displays the system IP routing table, showing destination, gateway, netmask, interface, and metric. Cross-platform implementation using `ip route` on Linux and `route PRINT` on Windows.

• `traceroute` – Traces network path to hosts with configurable max hops and timeout. On Linux, automatically falls back to `tracepath` if `traceroute` requires root, or supports `--sudo` flag. Example: `nadzoring network-base traceroute 8.8.8.8 --max-hops 15`

• `whois` – Performs WHOIS lookups for domains or IP addresses, parsing registration information into structured fields (registrar, dates, name servers, etc.). Example: `nadzoring network-base whois example.com`

**Implementation Details:**
- All commands are cross-platform (Linux/Windows) with OS detection
- Proper error handling and permission fallbacks (e.g., `traceroute` falls back to `tracepath` when root is needed)
- Progress indicators with tqdm for long-running operations
- Consistent output formatting for easy parsing and readability

**Documentation Updates:**
- Updated README.md
- Updated CONTRIBUTING.md with guidelines
- Updated Sphinx documentation (conf.py, index.rst)
