### PR TITLE
add arp spoofing, monitor and cache commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+commit 8c151e0560c51f7211f21ef111fa66f0c9c88dde
+Author: Alexeev Bronislav <alexeev.dev@mail.ru>
+Date:   Wed Mar 4 17:30:18 2026 +0700
+
+    update latest-docs
+
 commit 60bc7b0d138a331c483f6d4fe7bdb2c3519d153e
 Merge: bf29a83 573fbe3
 Author: Alexeev Bronislav <alexeev.dev@mail.ru>

--- a/src/nadzoring/arp/__init__.py
+++ b/src/nadzoring/arp/__init__.py
@@ -1,0 +1,21 @@
+"""
+ARP module for cache retrieval and spoofing detection.
+
+This module provides functionality to retrieve and parse ARP cache entries
+across different platforms and detect potential ARP spoofing attacks.
+"""
+
+from nadzoring.arp.cache import ARPCache, ARPCacheRetrievalError
+from nadzoring.arp.detector import ARPSpoofingDetector
+from nadzoring.arp.models import ARPEntry, ARPEntryState, SpoofingAlert
+from nadzoring.arp.realtime import ARPRealtimeDetector
+
+__all__ = [
+    "ARPCache",
+    "ARPCacheRetrievalError",
+    "ARPEntry",
+    "ARPEntryState",
+    "ARPRealtimeDetector",
+    "ARPSpoofingDetector",
+    "SpoofingAlert",
+]

--- a/src/nadzoring/arp/cache.py
+++ b/src/nadzoring/arp/cache.py
@@ -1,0 +1,306 @@
+"""ARP cache retrieval functionality."""
+
+import re
+import subprocess
+import sys
+from re import Match
+from shutil import which
+from subprocess import CompletedProcess
+from typing import Literal
+
+from nadzoring.arp.models import ARPEntry, ARPEntryState
+
+
+class ARPCacheRetrievalError(Exception):
+    """Raised when ARP cache retrieval fails."""
+
+
+class ARPCache:
+    """
+    ARP cache retrieval and parsing.
+
+    Provides platform-specific methods to retrieve and parse ARP cache entries
+    from Linux, Windows, and macOS systems. Automatically detects the current
+    platform and uses the appropriate command and parser.
+
+    Examples:
+        >>> cache = ARPCache()
+        >>> entries = cache.get_cache()
+        >>> for entry in entries:
+        ...     print(f"{entry.ip_address} -> {entry.mac_address}")
+
+    """
+
+    @staticmethod
+    def _get_platform() -> str:
+        """
+        Detect the current platform.
+
+        Returns:
+            Platform identifier: 'linux', 'windows', or 'darwin'.
+
+        Raises:
+            ARPCacheRetrievalError: If platform is not supported.
+
+        """
+        if sys.platform.startswith("linux"):
+            return "linux"
+        if sys.platform == "win32":
+            return "windows"
+        if sys.platform == "darwin":
+            return "darwin"
+        raise ARPCacheRetrievalError(f"Unsupported platform: {sys.platform}")
+
+    def get_cache(self) -> list[ARPEntry]:
+        """
+        Get ARP cache entries for current platform.
+
+        Automatically selects the appropriate method based on the detected
+        platform and returns parsed ARP entries.
+
+        Returns:
+            List of ARPEntry objects representing the current ARP cache.
+
+        Raises:
+            ARPCacheRetrievalError: If cache retrieval fails or platform is
+                unsupported.
+
+        """
+        platform: str = self._get_platform()
+        method = getattr(self, f"_get_{platform}_cache")
+        return method()
+
+    def _get_linux_cache(self) -> list[ARPEntry]:
+        """
+        Get ARP cache on Linux using 'ip neigh'.
+
+        Executes 'ip neigh show' command and parses the output.
+
+        Returns:
+            List of ARPEntry objects from Linux ARP cache.
+
+        Raises:
+            ARPCacheRetrievalError: If 'ip' command not found or execution fails.
+
+        """
+        ip_path: str | None = which("ip")
+        if not ip_path:
+            raise ARPCacheRetrievalError("'ip' command not found")
+
+        try:
+            result: CompletedProcess[str] = subprocess.run(  # noqa: S603
+                [ip_path, "neigh", "show"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            return self._parse_ip_neigh_output(result.stdout)
+        except subprocess.CalledProcessError as e:
+            raise ARPCacheRetrievalError(f"Failed to get ARP cache: {e}") from e
+
+    def _get_windows_cache(self) -> list[ARPEntry]:
+        """
+        Get ARP cache on Windows using 'arp -a'.
+
+        Executes 'arp -a' command and parses the output with Windows-specific
+        encoding (CP866).
+
+        Returns:
+            List of ARPEntry objects from Windows ARP cache.
+
+        Raises:
+            ARPCacheRetrievalError: If 'arp' command not found or execution fails.
+
+        """
+        arp_path = which("arp")
+        if not arp_path:
+            raise ARPCacheRetrievalError("'arp' command not found")
+
+        try:
+            result: CompletedProcess[str] = subprocess.run(  # noqa: S603
+                [arp_path, "-a"],
+                capture_output=True,
+                text=True,
+                check=True,
+                encoding="cp866" if sys.platform == "win32" else None,
+            )
+            return self._parse_windows_arp_output(result.stdout)
+        except subprocess.CalledProcessError as e:
+            raise ARPCacheRetrievalError(f"Failed to get ARP cache: {e}") from e
+
+    def _get_darwin_cache(self) -> list[ARPEntry]:
+        """
+        Get ARP cache on macOS using 'arp -a'.
+
+        Executes 'arp -a' command and parses the output.
+
+        Returns:
+            List of ARPEntry objects from macOS ARP cache.
+
+        Raises:
+            ARPCacheRetrievalError: If 'arp' command not found or execution fails.
+
+        """
+        arp_path: str | None = which("arp")
+        if not arp_path:
+            raise ARPCacheRetrievalError("'arp' command not found")
+
+        try:
+            result: CompletedProcess[str] = subprocess.run(  # noqa: S603
+                [arp_path, "-a"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            return self._parse_darwin_arp_output(result.stdout)
+        except subprocess.CalledProcessError as e:
+            raise ARPCacheRetrievalError(f"Failed to get ARP cache: {e}") from e
+
+    def _parse_ip_neigh_output(self, output: str) -> list[ARPEntry]:
+        """
+        Parse 'ip neigh' output on Linux.
+
+        Args:
+            output: Raw output from 'ip neigh show' command.
+
+        Returns:
+            List of parsed ARPEntry objects.
+
+        """
+        entries: list[ARPEntry] = []
+        for line in output.splitlines():
+            line = line.strip()  # noqa: PLW2901
+            if not line:
+                continue
+
+            parts = line.split()
+            if len(parts) < 3:
+                continue
+
+            ip: str = parts[0]
+            interface = None
+            mac = None
+            state = ARPEntryState.UNKNOWN
+
+            for i, part in enumerate(parts):
+                if part == "dev" and i + 1 < len(parts):
+                    interface = parts[i + 1]
+                elif part == "lladdr" and i + 1 < len(parts):
+                    mac = parts[i + 1]
+                elif part in [
+                    "REACHABLE",
+                    "STALE",
+                    "DELAY",
+                    "PROBE",
+                    "FAILED",
+                    "PERMANENT",
+                    "NOARP",
+                ]:
+                    state = ARPEntryState(part.lower())
+
+            if interface:
+                entries.append(
+                    ARPEntry(
+                        ip_address=ip,
+                        mac_address=mac,
+                        interface=interface,
+                        state=state,
+                    )
+                )
+
+        return entries
+
+    def _parse_windows_arp_output(self, output: str) -> list[ARPEntry]:
+        """
+        Parse 'arp -a' output on Windows.
+
+        Args:
+            output: Raw output from Windows 'arp -a' command.
+
+        Returns:
+            List of parsed ARPEntry objects.
+
+        """
+        entries: list[ARPEntry] = []
+        current_interface = None
+
+        for raw_line in output.splitlines():
+            line: str = raw_line.strip()
+            if not line:
+                continue
+
+            if line.startswith("Interface:"):
+                parts: list[str] = line.split()
+                if len(parts) >= 2:
+                    current_interface = parts[1]
+                continue
+
+            parts = line.split()
+            if len(parts) >= 3 and self._is_valid_ip(parts[0]):
+                ip: str = parts[0]
+                mac: str = parts[1].replace("-", ":")
+                state: Literal[ARPEntryState.PERMANENT, ARPEntryState.REACHABLE] = (
+                    ARPEntryState.REACHABLE
+                    if parts[2].lower() == "dynamic"
+                    else ARPEntryState.PERMANENT
+                )
+
+                entries.append(
+                    ARPEntry(
+                        ip_address=ip,
+                        mac_address=mac,
+                        interface=current_interface or "unknown",
+                        state=state,
+                    )
+                )
+
+        return entries
+
+    def _parse_darwin_arp_output(self, output: str) -> list[ARPEntry]:
+        """
+        Parse 'arp -a' output on macOS.
+
+        Args:
+            output: Raw output from macOS 'arp -a' command.
+
+        Returns:
+            List of parsed ARPEntry objects.
+
+        """
+        entries: list[ARPEntry] = []
+        pattern = r"\? \((\d+\.\d+\.\d+\.\d+)\) at ([\da-f:]+) on (\w+)"
+
+        for raw_line in output.splitlines():
+            match: Match[str] | None = re.search(pattern, raw_line, re.IGNORECASE)
+            if match:
+                ip, mac, interface = match.groups()
+                entries.append(
+                    ARPEntry(
+                        ip_address=ip,
+                        mac_address=mac,
+                        interface=interface,
+                        state=ARPEntryState.REACHABLE,
+                    )
+                )
+
+        return entries
+
+    @staticmethod
+    def _is_valid_ip(ip: str) -> bool:
+        """
+        Simple IP validation.
+
+        Args:
+            ip: IP address string to validate.
+
+        Returns:
+            True if string is a valid IPv4 address, False otherwise.
+
+        """
+        parts: list[str] = ip.split(".")
+        if len(parts) != 4:
+            return False
+        try:
+            return all(0 <= int(part) <= 255 for part in parts)
+        except ValueError:
+            return False

--- a/src/nadzoring/arp/detector.py
+++ b/src/nadzoring/arp/detector.py
@@ -1,0 +1,92 @@
+"""ARP spoofing detection logic."""
+
+from collections import defaultdict
+
+from nadzoring.arp.cache import ARPCache
+from nadzoring.arp.models import ARPEntry, SpoofingAlert
+
+
+class ARPSpoofingDetector:
+    """
+    Detects potential ARP spoofing attacks.
+
+    Analyzes ARP cache entries to identify potential spoofing attempts by
+    detecting duplicate MAC addresses across different IPs or duplicate IP
+    addresses across different MACs.
+
+    Attributes:
+        cache: ARPCache instance used to retrieve ARP entries.
+
+    """
+
+    def __init__(self, cache: ARPCache) -> None:
+        """
+        Initialize detector with ARP cache.
+
+        Args:
+            cache: ARPCache instance for retrieving ARP entries.
+
+        """
+        self.cache = cache
+
+    def detect(self) -> list[SpoofingAlert]:
+        """
+        Detect potential ARP spoofing in current cache.
+
+        Analyzes all ARP entries and generates alerts for suspicious patterns:
+        - Same MAC address associated with multiple IPs (duplicate_mac)
+        - Same IP address associated with multiple MACs (duplicate_ip)
+
+        Returns:
+            List of SpoofingAlert objects for each detected anomaly.
+
+        """
+        entries: list[ARPEntry] = self.cache.get_cache()
+        alerts: list[SpoofingAlert] = []
+
+        valid_entries: list[ARPEntry] = [e for e in entries if e.has_mac]
+
+        mac_to_entries: dict[str, list[ARPEntry]] = defaultdict(list)
+        for entry in valid_entries:
+            if entry.mac_address:
+                mac_to_entries[entry.mac_address].append(entry)
+
+        for mac, mac_entries in mac_to_entries.items():
+            if len(mac_entries) > 1:
+                ips: list[str] = [e.ip_address for e in mac_entries]
+                interfaces: list[str] = list({e.interface for e in mac_entries})
+                alerts.append(
+                    SpoofingAlert(
+                        alert_type="duplicate_mac",
+                        ip_address=ips[0],
+                        mac_address=mac,
+                        interfaces=interfaces,
+                        description=(
+                            f"MAC address {mac} is used by IPs: {', '.join(ips)}. "
+                            "This could indicate ARP spoofing."
+                        ),
+                    )
+                )
+
+        ip_to_entries: dict[str, list[ARPEntry]] = defaultdict(list)
+        for entry in valid_entries:
+            ip_to_entries[entry.ip_address].append(entry)
+
+        for ip, ip_entries in ip_to_entries.items():
+            if len(ip_entries) > 1:
+                macs: list[str] = [e.mac_address for e in ip_entries if e.mac_address]
+                interfaces = list({e.interface for e in ip_entries})
+                alerts.append(
+                    SpoofingAlert(
+                        alert_type="duplicate_ip",
+                        ip_address=ip,
+                        mac_address=macs[0],
+                        interfaces=interfaces,
+                        description=(
+                            f"IP address {ip} is claimed by MACs: {', '.join(macs)}. "
+                            "This is a strong indicator of ARP spoofing."
+                        ),
+                    )
+                )
+
+        return alerts

--- a/src/nadzoring/arp/models.py
+++ b/src/nadzoring/arp/models.py
@@ -1,0 +1,92 @@
+"""Data models for ARP module."""
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ARPEntryState(Enum):
+    """
+    ARP entry state enumeration.
+
+    Represents the possible states of an ARP cache entry as defined by the
+    Linux kernel neighbor subsystem.
+
+    Attributes:
+        REACHABLE: Entry is valid and reachable.
+        STALE: Entry is valid but possibly unreachable.
+        DELAY: Waiting for confirmation before probing.
+        PROBE: Actively probing the entry.
+        FAILED: Entry has failed resolution.
+        PERMANENT: Manually configured permanent entry.
+        NOARP: Device does not support ARP.
+        UNKNOWN: State could not be determined.
+
+    """
+
+    REACHABLE = "reachable"
+    STALE = "stale"
+    DELAY = "delay"
+    PROBE = "probe"
+    FAILED = "failed"
+    PERMANENT = "permanent"
+    NOARP = "noarp"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class ARPEntry:
+    """
+    Represents a single ARP cache entry.
+
+    Contains information about an IP-to-MAC address mapping from the system's
+    ARP cache.
+
+    Attributes:
+        ip_address: IP address in string format (e.g., "192.168.1.1").
+        mac_address: MAC address in string format (e.g., "00:11:22:33:44:55").
+            May be None for incomplete entries.
+        interface: Network interface name (e.g., "eth0", "wlan0").
+        state: Current state of the ARP entry.
+        flags: Additional flags or attributes (platform-specific).
+
+    """
+
+    ip_address: str
+    mac_address: str | None
+    interface: str
+    state: ARPEntryState
+    flags: str | None = None
+
+    @property
+    def has_mac(self) -> bool:
+        """
+        Check if entry has MAC address.
+
+        Returns:
+            True if entry has a valid MAC address, False for incomplete entries.
+
+        """
+        return self.mac_address is not None and self.mac_address != "(incomplete)"
+
+
+@dataclass
+class SpoofingAlert:
+    """
+    Represents a potential ARP spoofing alert.
+
+    Generated when suspicious patterns are detected in ARP cache entries.
+
+    Attributes:
+        alert_type: Type of alert ("duplicate_mac" or "duplicate_ip").
+        ip_address: IP address involved in the alert.
+        mac_address: MAC address involved in the alert.
+        interfaces: List of network interfaces where the issue was detected.
+        description: Human-readable description of the alert.
+
+    """
+
+    alert_type: str
+    ip_address: str
+    mac_address: str
+    interfaces: list[str]
+    description: str

--- a/src/nadzoring/arp/realtime.py
+++ b/src/nadzoring/arp/realtime.py
@@ -1,0 +1,184 @@
+"""
+Real-time ARP spoofing detection using packet sniffing.
+
+This module provides real-time monitoring of network traffic to detect
+ARP spoofing attacks by analyzing ARP packets and tracking IP-to-MAC
+address mappings.
+
+Example:
+    >>> detector = ARPRealtimeDetector()
+    >>> alerts = detector.monitor(interface="eth0", count=100)
+    >>> for alert in alerts:
+    ...     print(alert["message"])
+
+"""
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any
+
+from scapy.all import ARP, Ether, sniff  # type: ignore
+
+from nadzoring.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class ARPRealtimeDetector:
+    """
+    Real-time ARP spoofing detector using packet analysis.
+
+    Monitors network traffic for ARP packets and detects potential spoofing
+    attacks by tracking IP-to-MAC mappings and identifying inconsistencies.
+
+    The detector maintains a mapping of MAC addresses to their associated IPs.
+    When a packet is received, it checks if the MAC address already has a
+    different IP associated with it, which would indicate a potential spoofing
+    attack.
+
+    Attributes:
+        ip_mac_map: Dictionary mapping MAC addresses to their associated IPs.
+            Format: {mac_address: ip_address}
+        stats: Dictionary with monitoring statistics.
+
+    """
+
+    def __init__(self) -> None:
+        """Initialize the real-time ARP spoofing detector."""
+        self.ip_mac_map: dict[str, str] = {}
+        self.stats: dict[str, int] = {
+            "packets_processed": 0,
+            "alerts_generated": 0,
+            "unique_macs_seen": 0,
+        }
+
+    def process_packet(self, packet: Ether) -> str | None:
+        """
+        Process a single network packet for ARP spoofing detection.
+
+        Args:
+            packet: Scapy packet object to analyze. Must contain ARP and
+                Ethernet layers.
+
+        Returns:
+            Alert message if ARP spoofing detected, None otherwise.
+            The message format:
+                "ARP attack detected from machine with IP {old_ip} for {new_ip}"
+
+        """
+        if not packet.haslayer(ARP) or not packet.haslayer(Ether):
+            return None
+
+        src_ip: str = packet[ARP].psrc
+        src_mac: str = packet[Ether].src
+
+        self.stats["packets_processed"] += 1
+
+        if src_mac in self.ip_mac_map:
+            known_ip: str = self.ip_mac_map[src_mac]
+            if known_ip != src_ip:
+                self.stats["alerts_generated"] += 1
+                message: str = (
+                    f"ARP attack detected from machine with IP {known_ip} for {src_ip}"
+                )
+                logger.warning(message)
+                return message
+        else:
+            self.ip_mac_map[src_mac] = src_ip
+            self.stats["unique_macs_seen"] = len(self.ip_mac_map)
+
+        return None
+
+    def monitor(
+        self,
+        interface: str | None = None,
+        count: int = 10,
+        timeout: int = 30,
+        packet_callback: Callable[[Ether, str | None], None] | None = None,
+    ) -> list[dict[str, Any]]:
+        """
+        Monitor network for ARP spoofing attacks and return alerts.
+
+        Args:
+            interface: Network interface to monitor (None for all interfaces).
+            count: Number of packets to capture (0 for infinite).
+            timeout: Timeout in seconds (0 for no timeout).
+            packet_callback: Optional callback function that receives
+                the packet and alert message for custom handling.
+
+        Returns:
+            List of alert dictionaries, each containing:
+                - timestamp: ISO format timestamp
+                - interface: Interface being monitored
+                - message: Alert message text
+                - src_ip: Source IP address
+                - src_mac: Source MAC address
+
+        Raises:
+            RuntimeError: If packet sniffing fails.
+
+        """
+        alerts: list[dict[str, Any]] = []
+
+        def _default_callback(packet: Ether, alert: str | None) -> None:
+            """Default packet callback that collects alerts."""
+            if alert:
+                alerts.append(
+                    {
+                        "timestamp": datetime.now(UTC).isoformat(),
+                        "interface": interface or "all",
+                        "message": alert,
+                        "src_ip": getattr(packet[ARP], "psrc", "unknown"),
+                        "src_mac": getattr(packet[Ether], "src", "unknown"),
+                    }
+                )
+
+        callback: Callable[[Ether, str | None], None] = (
+            packet_callback if packet_callback is not None else _default_callback
+        )
+
+        logger.info(
+            "Starting ARP spoofing monitoring on %s",
+            interface if interface is not None else "all interfaces",
+        )
+
+        def _packet_handler(packet: Ether) -> None:
+            """Handle incoming packet and invoke callback."""
+            alert: str | None = self.process_packet(packet)
+            callback(packet, alert)
+
+        try:
+            sniff(
+                iface=interface,
+                filter="arp",
+                prn=_packet_handler,
+                store=False,
+                count=count if count > 0 else None,
+                timeout=timeout if timeout > 0 else None,
+            )
+        except Exception as e:
+            raise RuntimeError(f"Failed to sniff packets: {e}") from e
+
+        return alerts
+
+    def get_stats(self) -> dict[str, int]:
+        """
+        Get monitoring statistics.
+
+        Returns:
+            Dictionary with statistics:
+                - packets_processed: Total packets analyzed
+                - alerts_generated: Number of alerts detected
+                - unique_macs_seen: Number of unique MAC addresses seen
+
+        """
+        return self.stats.copy()
+
+    def reset(self) -> None:
+        """Reset detector state and statistics."""
+        self.ip_mac_map.clear()
+        self.stats = {
+            "packets_processed": 0,
+            "alerts_generated": 0,
+            "unique_macs_seen": 0,
+        }

--- a/src/nadzoring/cli.py
+++ b/src/nadzoring/cli.py
@@ -3,7 +3,7 @@
 
 import click
 
-from nadzoring.commands import dns_commands, network_commands
+from nadzoring.commands import arp_group, dns_group, network_group
 
 
 @click.group()
@@ -11,8 +11,9 @@ def cli() -> None:
     """FOSS tool for detecting website blocks, downdetecting and network analysis."""
 
 
-cli.add_command(dns_commands.dns)
-cli.add_command(network_commands.network_base)
+cli.add_command(network_group)
+cli.add_command(dns_group)
+cli.add_command(arp_group)
 
 
 def main() -> None:

--- a/src/nadzoring/commands/__init__.py
+++ b/src/nadzoring/commands/__init__.py
@@ -1,0 +1,11 @@
+"""Command modules initialization."""
+
+from nadzoring.commands.arp_commands import arp_group
+from nadzoring.commands.dns_commands import dns_group
+from nadzoring.commands.network_commands import network_group
+
+__all__ = [
+    "arp_group",
+    "dns_group",
+    "network_group",
+]

--- a/src/nadzoring/commands/arp_commands.py
+++ b/src/nadzoring/commands/arp_commands.py
@@ -1,0 +1,187 @@
+"""ARP-related CLI commands."""
+
+from datetime import UTC, datetime
+from typing import Any
+
+import click
+from scapy.all import ARP, Ether, sniff
+from tqdm import tqdm
+
+from nadzoring.arp import ARPCache, ARPCacheRetrievalError, ARPSpoofingDetector
+from nadzoring.arp.realtime import ARPRealtimeDetector
+from nadzoring.logger import get_logger
+from nadzoring.utils.decorators import common_cli_options
+
+logger = get_logger(__name__)
+
+
+@click.group(name="arp")
+def arp_group() -> None:
+    """ARP cache management and security commands."""
+
+
+@arp_group.command(name="cache")
+@common_cli_options(include_quiet=True)
+def show_cache(*, quiet: bool) -> list[dict[str, Any]]:
+    """Show current ARP cache table."""
+    try:
+        cache = ARPCache()
+        entries = cache.get_cache()
+    except ARPCacheRetrievalError as e:
+        raise click.ClickException(str(e)) from e
+
+    return [
+        {
+            "ip_address": entry.ip_address,
+            "mac_address": entry.mac_address or "(incomplete)",
+            "interface": entry.interface,
+            "state": entry.state.value,
+        }
+        for entry in entries
+    ]
+
+
+@arp_group.command(name="detect-spoofing")
+@common_cli_options(include_quiet=True)
+@click.argument("interfaces", nargs=-1, required=False)
+def detect_spoofing(
+    interfaces: tuple[str, ...], *, quiet: bool
+) -> list[dict[str, Any]]:
+    """
+    Detect potential ARP spoofing attacks on one or more interfaces.
+
+    If no interfaces specified, checks all interfaces.
+    """
+    try:
+        cache = ARPCache()
+        all_entries = cache.get_cache()
+    except ARPCacheRetrievalError as e:
+        raise click.ClickException(str(e)) from e
+
+    if interfaces:
+        entries = [e for e in all_entries if e.interface in interfaces]
+        if not entries and not quiet:
+            click.echo(
+                f"No ARP entries found for interfaces: {', '.join(interfaces)}",
+                err=True,
+            )
+    else:
+        entries = all_entries
+
+    detector = ARPSpoofingDetector(cache)
+    interfaces_to_check = list({e.interface for e in entries})
+
+    total = len(interfaces_to_check)
+    pbar = (
+        None if quiet else tqdm(total=total, desc="Analyzing interfaces", unit="iface")
+    )
+
+    all_alerts = []
+    for interface in interfaces_to_check:
+        interface_entries = [e for e in entries if e.interface == interface]
+        alerts = detector.detect_on_interface(interface_entries, interface)
+
+        all_alerts.extend(
+            {
+                "alert_type": alert.alert_type,
+                "ip_address": alert.ip_address,
+                "mac_address": alert.mac_address,
+                "interface": alert.interface,
+                "description": alert.description,
+            }
+            for alert in alerts
+        )
+
+        if pbar:
+            pbar.set_description(f"Analyzing {interface}")
+            pbar.update(1)
+
+    if pbar:
+        pbar.close()
+
+    return all_alerts
+
+
+@arp_group.command(name="monitor-spoofing")
+@common_cli_options(include_quiet=True, include_output=True, include_save=True)
+@click.option(
+    "--interface",
+    "-i",
+    default=None,
+    help="Network interface to monitor (default: all interfaces).",
+)
+@click.option(
+    "--count",
+    "-c",
+    default=10,
+    help="Number of packets to capture (default: 10).",
+    show_default=True,
+)
+@click.option(
+    "--timeout",
+    "-t",
+    default=30,
+    help="Timeout in seconds (default: 30).",
+    show_default=True,
+)
+def monitor_spoofing(
+    interface: str | None,
+    count: int,
+    timeout: int,
+    *,
+    quiet: bool,
+    output: str,
+    save: str | None,
+) -> list[dict[str, Any]]:
+    """
+    Monitor network for ARP spoofing attacks in real-time.
+
+    Captures ARP packets on the specified interface and detects potential
+    spoofing attacks by tracking IP-to-MAC mappings.
+    """
+    alerts: list[dict[str, Any]] = []
+
+    try:
+        detector = ARPRealtimeDetector()
+
+        def packet_callback(packet: Any) -> None:
+            """Process packet and collect alerts."""
+            alert = detector.process_packet(packet)
+            if alert:
+                alert_dict = {
+                    "timestamp": datetime.now(UTC).isoformat(),
+                    "interface": interface or "all",
+                    "message": alert,
+                    "src_ip": getattr(packet[ARP], "psrc", "unknown"),
+                    "src_mac": getattr(packet[Ether], "src", "unknown"),
+                }
+                alerts.append(alert_dict)
+
+                if not quiet:
+                    click.secho(f"\n! {alert}", fg="red", bold=True)
+
+        if not quiet:
+            click.echo(
+                f"Monitoring ARP spoofing on {interface or 'all interfaces'}...\n"
+                f"Press Ctrl+C to stop."
+            )
+
+        packets = sniff(
+            iface=interface,
+            filter="arp",
+            prn=packet_callback,
+            store=False,
+            count=count if count > 0 else None,
+            timeout=timeout if timeout > 0 else None,
+        )
+
+        if not quiet:
+            click.echo(f"\nCaptured {len(packets)} ARP packets.")
+
+    except KeyboardInterrupt:
+        if not quiet:
+            click.echo("\n\nMonitoring stopped by user.")
+    except Exception as e:
+        raise click.ClickException(f"Monitoring failed: {e}") from e
+
+    return alerts

--- a/src/nadzoring/commands/dns_commands.py
+++ b/src/nadzoring/commands/dns_commands.py
@@ -34,11 +34,11 @@ logger: Logger = get_logger(__name__)
 
 
 @click.group(name="dns")
-def dns() -> None:
+def dns_group() -> None:
     """DNS lookup and analysis commands."""
 
 
-@dns.command(name="resolve")
+@dns_group.command(name="resolve")
 @common_cli_options(include_quiet=True)
 @click.argument("domains", nargs=-1, required=True)
 @click.option(
@@ -109,7 +109,7 @@ def resolve_command(
     return format_dns_record(results, style=format_style, show_ttl=show_ttl)
 
 
-@dns.command(name="reverse")
+@dns_group.command(name="reverse")
 @common_cli_options(include_quiet=True)
 @click.argument("ip_addresses", nargs=-1, required=True)
 @click.option("--nameserver", "-n", help="Specific nameserver to use")
@@ -148,7 +148,7 @@ def reverse_command(
     return results
 
 
-@dns.command(name="check")
+@dns_group.command(name="check")
 @common_cli_options(include_quiet=True)
 @click.argument("domains", nargs=-1, required=True)
 @click.option("--nameserver", "-n", help="Specific nameserver to use")
@@ -219,7 +219,7 @@ def check_command(
     return results
 
 
-@dns.command(name="trace")
+@dns_group.command(name="trace")
 @common_cli_options(include_quiet=True)
 @click.argument("domain", required=True)
 @click.option("--nameserver", "-n", help="Starting nameserver to use")
@@ -237,7 +237,7 @@ def trace_command(
     return format_dns_trace(result)
 
 
-@dns.command(name="compare")
+@dns_group.command(name="compare")
 @common_cli_options(include_quiet=True)
 @click.argument("domain", required=True)
 @click.option(
@@ -287,7 +287,7 @@ def compare_command(
     return format_dns_comparison(result)
 
 
-@dns.command(name="health")
+@dns_group.command(name="health")
 @common_cli_options(include_quiet=True)
 @click.argument("domain", required=True)
 @click.option("--nameserver", "-n", help="Nameserver to use for checks")
@@ -305,7 +305,7 @@ def health_command(
     return format_dns_health(result)
 
 
-@dns.command(name="benchmark")
+@dns_group.command(name="benchmark")
 @common_cli_options(include_quiet=True)
 @click.option(
     "--domain",
@@ -390,7 +390,7 @@ def benchmark_command(
     ]
 
 
-@dns.command(name="poisoning")
+@dns_group.command(name="poisoning")
 @common_cli_options(include_quiet=True)
 @click.argument("domain", required=True)
 @click.option(

--- a/src/nadzoring/commands/network_commands.py
+++ b/src/nadzoring/commands/network_commands.py
@@ -37,11 +37,11 @@ logger: Logger = get_logger(__name__)
 
 
 @click.group(name="network-base")
-def network_base() -> None:
+def network_group() -> None:
     """Network base commands for analysis and diagnostics."""
 
 
-@network_base.command(name="port-scan")
+@network_group.command(name="port-scan")
 @common_cli_options(include_quiet=True)
 @click.argument("targets", nargs=-1, required=True)
 @click.option(
@@ -205,7 +205,7 @@ def _parse_port_specification(
     return custom_ports, None
 
 
-@network_base.command(name="ping")
+@network_group.command(name="ping")
 @common_cli_options(include_quiet=True)
 @click.argument("addresses", type=str, nargs=-1, required=True)
 def ping_command(
@@ -238,7 +238,7 @@ def ping_command(
     return results
 
 
-@network_base.command(name="geolocation")
+@network_group.command(name="geolocation")
 @common_cli_options(include_quiet=True)
 @click.argument("ips", type=str, nargs=-1, required=True)
 def geolocation_command(
@@ -273,7 +273,7 @@ def geolocation_command(
     return results
 
 
-@network_base.command(name="params")
+@network_group.command(name="params")
 @common_cli_options(include_quiet=True)
 def params_command(*, quiet: bool = False) -> list[dict]:
     """Get network parameters for the current system."""
@@ -282,7 +282,7 @@ def params_command(*, quiet: bool = False) -> list[dict]:
     return [data]
 
 
-@network_base.command(name="host-to-ip")
+@network_group.command(name="host-to-ip")
 @common_cli_options(include_quiet=True)
 @click.argument("hostnames", type=str, nargs=-1, required=True)
 def host_to_ip_command(
@@ -324,7 +324,7 @@ def host_to_ip_command(
     return results
 
 
-@network_base.command(name="port-service")
+@network_group.command(name="port-service")
 @common_cli_options(include_quiet=True)
 @click.argument("ports", type=int, nargs=-1, required=True)
 def port_service_command(
@@ -357,7 +357,7 @@ def port_service_command(
     return results
 
 
-@network_base.command(name="http-ping")
+@network_group.command(name="http-ping")
 @common_cli_options(include_quiet=True)
 @click.argument("urls", nargs=-1, required=True)
 @click.option(
@@ -449,7 +449,7 @@ def http_ping_command(
     return results
 
 
-@network_base.command(name="whois")
+@network_group.command(name="whois")
 @common_cli_options(include_quiet=True)
 @click.argument("targets", nargs=-1, required=True)
 def whois_command(
@@ -484,7 +484,7 @@ def whois_command(
     return results
 
 
-@network_base.command(name="connections")
+@network_group.command(name="connections")
 @common_cli_options(include_quiet=True)
 @click.option(
     "--protocol",
@@ -544,7 +544,7 @@ def connections_command(
     return results
 
 
-@network_base.command(name="traceroute")
+@network_group.command(name="traceroute")
 @common_cli_options(include_quiet=True)
 @click.argument("targets", nargs=-1, required=True)
 @click.option(
@@ -622,7 +622,7 @@ def traceroute_command(
     return results
 
 
-@network_base.command(name="route")
+@network_group.command(name="route")
 @common_cli_options(include_quiet=True)
 def route_command(*, quiet: bool = False) -> list[dict[str, Any]]:
     """


### PR DESCRIPTION
This PR introduces a new ARP module that provides both static cache analysis and real-time spoofing detection capabilities. The module is integrated into the CLI with three main commands.

### Key Changes

**New Module Structure:**
- Added `src/nadzoring/arp/` with cache retrieval, spoofing detection, and packet monitoring components
- Created `src/nadzoring/commands/arp_commands.py` for CLI integration
- Updated CLI entry points to register the new command group

**Core Functionality:**

1. **ARP Cache Inspection**
```bash
nadzoring arp cache
```
Displays the current ARP table with IP, MAC, interface, and state information. Cross-platform support for Linux (ip neigh), Windows (arp -a), and macOS.

2. **Static Spoofing Detection**
```bash
nadzoring arp detect-spoofing [INTERFACES...]
```
Analyzes ARP cache for duplicate MACs across different IPs or duplicate IPs across different MACs. Returns structured alerts with severity levels.

3. **Real-time Monitoring**
```bash
nadzoring arp monitor-spoofing -i eth0 -c 50 -t 30
```
Captures ARP packets in real-time using Scapy, tracks IP-MAC mappings, and generates alerts when inconsistencies are detected. Results can be output in table, JSON, CSV, or HTML formats.
