### PR TITLE
feat: add monitor and monitor-report commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+commit e206893ea04a6c19255479fa6192bdf5bff576f4
+Author: Alexeev Bronislav <alexeev.dev@mail.ru>
+Date:   Fri Mar 6 23:41:48 2026 +0700
+
+    docs: update readme and improve docs
+
 commit 3aae4d42a0069781e49ae3c60fd61b43f863e9c6
 Author: Alexeev Bronislav <alexeev.dev@mail.ru>
 Date:   Fri Mar 6 23:24:55 2026 +0700

--- a/README.md
+++ b/README.md
@@ -91,7 +91,11 @@ Nadzoring (from Russian "надзор" — supervision/oversight + English "-ing
     - [ARP Spoofing Detection](#arp-spoofing-detection)
     - [Network Path Analysis](#network-path-analysis)
     - [Complete Network Diagnostics](#complete-network-diagnostics)
-    - [Automated Monitoring Script](#automated-monitoring-script)
+    - [Automated DNS Server Monitoring](#automated-dns-server-monitoring)
+      - [Shell script with alerting thresholds](#shell-script-with-alerting-thresholds)
+      - [Scheduling with cron (Linux/macOS)](#scheduling-with-cron-linuxmacos)
+      - [Scheduling with systemd timer (Linux, recommended)](#scheduling-with-systemd-timer-linux-recommended)
+      - [Python continuous monitoring loop (in-process)](#python-continuous-monitoring-loop-in-process)
     - [Quick Website Block Check](#quick-website-block-check)
   - [Contributing](#contributing)
   - [Documentation](#documentation)
@@ -1158,23 +1162,263 @@ nadzoring network-base traceroute cloudflare.com
 nadzoring arp cache
 ```
 
-### Automated Monitoring Script
+### Automated DNS Server Monitoring
+
+This section covers three integration approaches for continuous monitoring:
+a **shell script** for use with cron/systemd, a **Python script** for
+in-process loops with alerting, and **scheduling setup** for both Linux and Windows.
+
+#### Shell script with alerting thresholds
+
+Save as `dns_monitor.sh` and make executable (`chmod +x dns_monitor.sh`):
 
 ```bash
 #!/bin/bash
-TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+# dns_monitor.sh — continuous DNS health and performance monitor
+# Designed to be called by cron or systemd timer.
 
-nadzoring dns health     -o json --save "dns_health_${TIMESTAMP}.json"     example.com
-nadzoring dns poisoning  -o html --save "poisoning_${TIMESTAMP}.html"       example.com
-nadzoring dns trace      -o html --save "dns_trace_${TIMESTAMP}.html"       example.com
-nadzoring dns reverse    -o json --save "reverse_${TIMESTAMP}.json"         8.8.8.8 1.1.1.1
-nadzoring network-base params    -o csv  --save "network_${TIMESTAMP}.csv"
-nadzoring dns benchmark  -o table --save "benchmark_${TIMESTAMP}.txt"
-nadzoring network-base port-scan -o json --save "port_scan_${TIMESTAMP}.json" example.com
-nadzoring network-base http-ping --show-headers -o html --save "http_${TIMESTAMP}.html" https://example.com
-nadzoring arp cache      -o csv  --save "arp_${TIMESTAMP}.csv"
+set -euo pipefail
+
+# ── Configuration ────────────────────────────────────────────────────────────
+TARGET_DOMAIN="${1:-example.com}"
+DNS_SERVER="${2:-8.8.8.8}"
+REPORT_DIR="${DNS_MONITOR_DIR:-/var/log/nadzoring}"
+ALERT_EMAIL="${DNS_ALERT_EMAIL:-}"        # leave empty to disable email alerts
+HEALTH_THRESHOLD=70                       # score below this triggers an alert
+BENCHMARK_QUERIES=5                       # queries per server for each run
+
+# ── Setup ────────────────────────────────────────────────────────────────────
+mkdir -p "$REPORT_DIR"
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+LOG_FILE="$REPORT_DIR/monitor_${TIMESTAMP}.log"
+SUMMARY_FILE="$REPORT_DIR/summary.jsonl"  # append-only JSONL for trend analysis
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"; }
+alert() {
+    log "ALERT: $*"
+    if [[ -n "$ALERT_EMAIL" ]]; then
+        echo "$*" | mail -s "[nadzoring] DNS alert: $TARGET_DOMAIN" "$ALERT_EMAIL" || true
+    fi
+}
+
+# ── DNS Health Check ─────────────────────────────────────────────────────────
+log "Starting DNS health check for $TARGET_DOMAIN via $DNS_SERVER"
+
+HEALTH_JSON="$REPORT_DIR/health_${TIMESTAMP}.json"
+if nadzoring dns health -n "$DNS_SERVER" -o json --quiet \
+        --save "$HEALTH_JSON" "$TARGET_DOMAIN"; then
+    SCORE=$(python3 -c "import json,sys; d=json.load(open('$HEALTH_JSON')); print(d.get('score',0))" 2>/dev/null || echo 0)
+    STATUS=$(python3 -c "import json,sys; d=json.load(open('$HEALTH_JSON')); print(d.get('status','unknown'))" 2>/dev/null || echo unknown)
+    log "Health score: $SCORE ($STATUS)"
+
+    if [[ "$SCORE" -lt "$HEALTH_THRESHOLD" ]]; then
+        alert "Health score $SCORE is below threshold $HEALTH_THRESHOLD (status: $STATUS) for $TARGET_DOMAIN"
+    fi
+else
+    alert "dns health check command failed for $TARGET_DOMAIN"
+    SCORE=0; STATUS="error"
+fi
+
+# ── DNS Benchmark ────────────────────────────────────────────────────────────
+BENCH_JSON="$REPORT_DIR/benchmark_${TIMESTAMP}.json"
+if nadzoring dns benchmark -s "$DNS_SERVER" -s 8.8.8.8 -s 1.1.1.1 \
+        -d "$TARGET_DOMAIN" -q "$BENCHMARK_QUERIES" \
+        -o json --quiet --save "$BENCH_JSON"; then
+    AVG_MS=$(python3 -c "
+import json
+data = json.load(open('$BENCH_JSON'))
+target = next((r for r in data if r['server'] == '$DNS_SERVER'), None)
+print(round(target['avg_response_time'], 1) if target else 'N/A')
+" 2>/dev/null || echo "N/A")
+    log "Benchmark avg response time for $DNS_SERVER: ${AVG_MS}ms"
+else
+    log "WARNING: benchmark failed"
+    AVG_MS="N/A"
+fi
+
+# ── DNS Compare (discrepancy detection) ─────────────────────────────────────
+COMPARE_JSON="$REPORT_DIR/compare_${TIMESTAMP}.json"
+nadzoring dns compare -t A -t MX \
+    -s "$DNS_SERVER" -s 8.8.8.8 -s 1.1.1.1 \
+    -o json --quiet --save "$COMPARE_JSON" "$TARGET_DOMAIN" || true
+
+DIFFS=$(python3 -c "
+import json
+data = json.load(open('$COMPARE_JSON'))
+diffs = data.get('differences', [])
+print(len(diffs))
+" 2>/dev/null || echo 0)
+
+if [[ "$DIFFS" -gt 0 ]]; then
+    alert "$DIFFS DNS discrepancies detected for $TARGET_DOMAIN — possible poisoning or misconfiguration"
+fi
+log "DNS compare: $DIFFS discrepancies found"
+
+# ── Reverse DNS Spot-check ───────────────────────────────────────────────────
+RESOLVED_IP=$(nadzoring network-base host-to-ip --quiet -o json "$TARGET_DOMAIN" 2>/dev/null \
+    | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0].get('ip','') if d else '')" 2>/dev/null || echo "")
+
+REVERSE_HOST="N/A"
+if [[ -n "$RESOLVED_IP" ]]; then
+    REVERSE_JSON="$REPORT_DIR/reverse_${TIMESTAMP}.json"
+    nadzoring dns reverse -n "$DNS_SERVER" -o json --quiet \
+        --save "$REVERSE_JSON" "$RESOLVED_IP" || true
+    REVERSE_HOST=$(python3 -c "
+import json
+data = json.load(open('$REVERSE_JSON'))
+print(data[0].get('hostname','N/A') if data else 'N/A')
+" 2>/dev/null || echo "N/A")
+    log "Reverse DNS for $RESOLVED_IP → $REVERSE_HOST"
+fi
+
+# ── Append to JSONL summary for trend analysis ───────────────────────────────
+python3 - <<EOF >> "$SUMMARY_FILE"
+import json, datetime
+print(json.dumps({
+    "timestamp": "$TIMESTAMP",
+    "domain": "$TARGET_DOMAIN",
+    "dns_server": "$DNS_SERVER",
+    "health_score": $SCORE,
+    "health_status": "$STATUS",
+    "avg_response_ms": "$AVG_MS",
+    "discrepancies": $DIFFS,
+    "resolved_ip": "$RESOLVED_IP",
+    "reverse_host": "$REVERSE_HOST",
+}))
+EOF
+
+log "Run complete. Reports saved to $REPORT_DIR"
 ```
 
+#### Scheduling with cron (Linux/macOS)
+
+```bash
+# Edit crontab
+crontab -e
+
+# Run every 5 minutes
+*/5 * * * * /path/to/dns_monitor.sh example.com 8.8.8.8
+
+# Run every hour with email alerts
+0 * * * * DNS_ALERT_EMAIL=ops@example.com /path/to/dns_monitor.sh example.com 8.8.8.8
+
+# Run every 15 minutes, logging cron output
+*/15 * * * * /path/to/dns_monitor.sh example.com 8.8.8.8 >> /var/log/nadzoring/cron.log 2>&1
+```
+
+#### Scheduling with systemd timer (Linux, recommended)
+
+Create `/etc/systemd/system/nadzoring-dns-monitor.service`:
+
+```ini
+[Unit]
+Description=Nadzoring DNS health monitor
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/path/to/dns_monitor.sh example.com 8.8.8.8
+Environment=DNS_MONITOR_DIR=/var/log/nadzoring
+Environment=DNS_ALERT_EMAIL=ops@example.com
+StandardOutput=journal
+StandardError=journal
+```
+
+Create `/etc/systemd/system/nadzoring-dns-monitor.timer`:
+
+```ini
+[Unit]
+Description=Run Nadzoring DNS monitor every 5 minutes
+
+[Timer]
+OnBootSec=60
+OnUnitActiveSec=5min
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable and start:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now nadzoring-dns-monitor.timer
+sudo systemctl status nadzoring-dns-monitor.timer
+journalctl -u nadzoring-dns-monitor.service -f   # follow live logs
+```
+
+#### Python continuous monitoring loop (in-process)
+
+Use `DNSMonitor` directly for in-process monitoring with custom alerting:
+
+**Infinite loop (blocks until Ctrl-C or SIGTERM):**
+
+```python
+from nadzoring.dns_lookup.monitor import AlertEvent, DNSMonitor, MonitorConfig
+
+
+def send_alert(alert: AlertEvent) -> None:
+    print(f"ALERT [{alert.alert_type}]: {alert.message}")
+
+
+config = MonitorConfig(
+    domain="example.com",
+    nameservers=["8.8.8.8", "1.1.1.1"],
+    interval=60.0,
+    max_response_time_ms=500.0,
+    min_success_rate=0.95,
+    log_file="dns_monitor.jsonl",
+    alert_callback=send_alert,
+)
+
+monitor = DNSMonitor(config)
+monitor.run()
+print(monitor.report())
+```
+
+**Finite cycles (CI pipelines, cron scripts):**
+
+```python
+from nadzoring.dns_lookup.monitor import DNSMonitor, MonitorConfig
+from statistics import mean
+
+config = MonitorConfig(
+    domain="example.com",
+    nameservers=["8.8.8.8", "1.1.1.1"],
+    interval=10.0,
+    run_health_check=False,
+)
+monitor = DNSMonitor(config)
+history = monitor.run_cycles(6)
+
+rts = [
+    s.avg_response_time_ms
+    for c in history
+    for s in c.samples
+    if s.avg_response_time_ms is not None
+]
+print(f"Mean RT: {mean(rts):.1f}ms")
+print(monitor.report())
+```
+
+**Analyse saved log:**
+
+```python
+from nadzoring.dns_lookup.monitor import load_log
+from statistics import mean
+
+cycles = load_log("dns_monitor.jsonl")
+rts = [
+    s["avg_response_time_ms"]
+    for c in cycles
+    for s in c["samples"]
+    if s["avg_response_time_ms"] is not None
+]
+alerts = [a for c in cycles for a in c.get("alerts", [])]
+print(f"Cycles: {len(cycles)}  Mean RT: {mean(rts):.1f}ms  Alerts: {len(alerts)}")
+```
 ### Quick Website Block Check
 
 ```bash

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,6 +37,7 @@ Key Features
 
    installation
    quickstart
+   monitoring_dns
 
 .. toctree::
    :maxdepth: 3

--- a/docs/source/monitoring_dns.rst
+++ b/docs/source/monitoring_dns.rst
@@ -1,0 +1,388 @@
+Continuous DNS Monitoring
+=========================
+
+Nadzoring provides a built-in monitoring loop that periodically checks one
+or more DNS servers, tracks trends over time, fires threshold-based alerts,
+and persists all results to a JSONL log for later analysis.
+
+----
+
+Quick Start
+-----------
+
+Monitor ``example.com`` against two DNS servers every 60 seconds:
+
+.. code-block:: bash
+
+   nadzoring dns monitor example.com \
+       -n 8.8.8.8 -n 1.1.1.1 \
+       --interval 60 \
+       --log-file dns_monitor.jsonl
+
+Press **Ctrl-C** to stop. A statistical summary prints automatically.
+
+----
+
+CLI Reference: ``dns monitor``
+--------------------------------
+
+.. code-block:: text
+
+   nadzoring dns monitor [OPTIONS] DOMAIN
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 6 52 18
+
+   * - Option
+     - Short
+     - Description
+     - Default
+   * - ``--nameservers``
+     - ``-n``
+     - DNS server IP to monitor (repeatable)
+     - ``8.8.8.8``, ``1.1.1.1``
+   * - ``--interval``
+     - ``-i``
+     - Seconds between monitoring cycles
+     - ``60``
+   * - ``--type``
+     - ``-t``
+     - Record type: A, AAAA, MX, NS, TXT
+     - ``A``
+   * - ``--queries``
+     - ``-q``
+     - Queries per server per cycle
+     - ``3``
+   * - ``--max-rt``
+     -
+     - Alert threshold: max avg response time (ms)
+     - ``500``
+   * - ``--min-success``
+     -
+     - Alert threshold: minimum success rate (0–1)
+     - ``0.95``
+   * - ``--no-health``
+     -
+     - Skip health check each cycle
+     - ``False``
+   * - ``--log-file``
+     - ``-l``
+     - JSONL file to append all cycle results to
+     - None
+   * - ``--cycles``
+     - ``-c``
+     - Stop after N cycles (0 = indefinite)
+     - ``0``
+   * - ``--output``
+     - ``-o``
+     - Output format: table, json, csv, html
+     - ``table``
+   * - ``--quiet``
+     -
+     - Suppress all console output
+     - ``False``
+
+**Examples:**
+
+.. code-block:: bash
+
+   nadzoring dns monitor example.com
+
+   nadzoring dns monitor example.com \
+       -n 8.8.8.8 -n 1.1.1.1 -n 9.9.9.9 \
+       --interval 30 --max-rt 150 --min-success 0.99 \
+       --log-file /var/log/dns_monitor.jsonl
+
+   nadzoring dns monitor example.com \
+       --interval 10 --no-health --queries 1
+
+   nadzoring dns monitor example.com \
+       --cycles 10 -o json --save report.json
+
+   nadzoring dns monitor example.com \
+       --quiet --log-file /var/log/dns_monitor.jsonl
+
+----
+
+CLI Reference: ``dns monitor-report``
+---------------------------------------
+
+Analyse a saved JSONL log and print aggregated per-server statistics:
+
+.. code-block:: bash
+
+   nadzoring dns monitor-report dns_monitor.jsonl
+
+   nadzoring dns monitor-report dns_monitor.jsonl --server 8.8.8.8
+
+   nadzoring dns monitor-report dns_monitor.jsonl -o json --save stats.json
+
+----
+
+What Happens Each Cycle
+------------------------
+
+1. **Benchmark** — sends ``--queries`` queries to each server and records
+   average, min, and max response times plus the success rate.
+
+2. **Resolve** — one additional query captures the current DNS records
+   returned by each server.
+
+3. **Health check** (skip with ``--no-health``) — computes an overall
+   score (0–100) across A, AAAA, MX, NS, TXT, and CNAME records.
+
+4. **Threshold evaluation** — compares metrics against configured
+   thresholds and generates alert events for any breaches.
+
+5. **Alert dispatch** — calls the configured ``alert_callback`` (if any)
+   and prints warnings to the console.
+
+6. **Persistence** — appends a JSON line to the log file (if configured).
+
+7. **Sleep** — waits ``--interval`` seconds before the next cycle.
+
+----
+
+Alert Types
+-----------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Type
+     - Triggered when
+   * - ``resolution_failure``
+     - All queries failed (success rate = 0 %)
+   * - ``high_latency``
+     - Average response time exceeds ``--max-rt``
+   * - ``low_success_rate``
+     - Success rate falls below ``--min-success``
+   * - ``health_degraded``
+     - DNS health score drops below 80
+
+----
+
+Log File Format
+---------------
+
+Each line in the JSONL log is a complete cycle result:
+
+.. code-block:: json
+
+   {
+     "cycle": 42,
+     "timestamp": "2025-06-01T14:23:10.123456+00:00",
+     "domain": "example.com",
+     "samples": [
+       {
+         "server": "8.8.8.8",
+         "timestamp": "2025-06-01T14:23:10.123456+00:00",
+         "avg_response_time_ms": 18.4,
+         "min_response_time_ms": 14.1,
+         "max_response_time_ms": 24.7,
+         "success_rate": 1.0,
+         "records": ["93.184.216.34"],
+         "error": null
+       }
+     ],
+     "health_score": 85,
+     "health_status": "healthy",
+     "alerts": []
+   }
+
+----
+
+Python API
+----------
+
+Basic continuous monitoring
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from nadzoring.dns_lookup.monitor import DNSMonitor, MonitorConfig
+
+   config = MonitorConfig(
+       domain="example.com",
+       nameservers=["8.8.8.8", "1.1.1.1"],
+       interval=60.0,
+       max_response_time_ms=500.0,
+       min_success_rate=0.95,
+       log_file="dns_monitor.jsonl",
+   )
+
+   monitor = DNSMonitor(config)
+   monitor.run()
+   print(monitor.report())
+
+Custom alert callback
+~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   import requests
+   from nadzoring.dns_lookup.monitor import AlertEvent, DNSMonitor, MonitorConfig
+
+   SLACK_WEBHOOK = "https://hooks.slack.com/services/T.../B.../..."
+
+
+   def send_slack_alert(alert: AlertEvent) -> None:
+       requests.post(
+           SLACK_WEBHOOK,
+           json={"text": f":warning: *{alert.alert_type}* — {alert.message}"},
+           timeout=5,
+       )
+
+
+   config = MonitorConfig(
+       domain="example.com",
+       nameservers=["8.8.8.8"],
+       interval=30.0,
+       max_response_time_ms=200.0,
+       alert_callback=send_slack_alert,
+   )
+   DNSMonitor(config).run()
+
+Finite-cycle monitoring (CI / cron)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from nadzoring.dns_lookup.monitor import DNSMonitor, MonitorConfig
+   from statistics import mean
+
+   config = MonitorConfig(
+       domain="example.com",
+       nameservers=["8.8.8.8", "1.1.1.1"],
+       interval=10.0,
+       queries_per_sample=5,
+       run_health_check=False,
+   )
+   monitor = DNSMonitor(config)
+   history = monitor.run_cycles(6)
+
+   rts = [
+       s.avg_response_time_ms
+       for c in history
+       for s in c.samples
+       if s.avg_response_time_ms is not None
+   ]
+   print(f"Mean RT over {len(history)} cycles: {mean(rts):.1f}ms")
+   print(monitor.report())
+
+Analysing a historical log
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   from nadzoring.dns_lookup.monitor import load_log
+   from statistics import mean
+
+   cycles = load_log("dns_monitor.jsonl")
+
+   rts = [
+       s["avg_response_time_ms"]
+       for c in cycles
+       for s in c["samples"]
+       if s["server"] == "8.8.8.8" and s["avg_response_time_ms"] is not None
+   ]
+   alerts = [a for c in cycles for a in c.get("alerts", [])]
+
+   print(f"Cycles      : {len(cycles)}")
+   print(f"Avg RT (ms) : {mean(rts):.2f}")
+   print(f"Alerts      : {len(alerts)}")
+
+----
+
+Scheduling
+----------
+
+Cron (one cycle per minute)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: cron
+
+   * * * * * root nadzoring dns monitor example.com \
+       --cycles 1 --quiet \
+       --log-file /var/log/nadzoring/dns_monitor.jsonl
+
+.. note::
+
+   Use ``--cycles 1`` with cron — the process exits after one check
+   and cron handles the interval.
+
+systemd service (recommended for production)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Create ``/etc/systemd/system/nadzoring-dns-monitor.service``:
+
+.. code-block:: ini
+
+   [Unit]
+   Description=Nadzoring DNS Monitor
+   After=network-online.target
+   Wants=network-online.target
+
+   [Service]
+   Type=simple
+   User=nobody
+   ExecStart=/usr/local/bin/nadzoring dns monitor example.com \
+       -n 8.8.8.8 -n 1.1.1.1 \
+       --interval 60 \
+       --max-rt 300 \
+       --min-success 0.95 \
+       --log-file /var/log/nadzoring/dns_monitor.jsonl \
+       --quiet
+   Restart=on-failure
+   RestartSec=10
+   StandardOutput=journal
+   StandardError=journal
+
+   [Install]
+   WantedBy=multi-user.target
+
+.. code-block:: bash
+
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now nadzoring-dns-monitor
+   sudo journalctl -u nadzoring-dns-monitor -f
+
+----
+
+Complete Automation Script
+---------------------------
+
+.. code-block:: bash
+
+   #!/usr/bin/env bash
+   # dns_health_check.sh — hourly DNS health snapshot for cron
+   set -euo pipefail
+
+   DOMAIN="${1:-example.com}"
+   LOG_DIR="/var/log/nadzoring"
+   TODAY=$(date -u +%Y%m%d)
+   TS=$(date -u +%Y%m%d_%H%M%S)
+   DAILY_LOG="${LOG_DIR}/dns_monitor_${TODAY}.jsonl"
+   REPORT_DIR="/var/www/html/dns-reports"
+
+   mkdir -p "$LOG_DIR" "$REPORT_DIR"
+
+   nadzoring dns monitor "$DOMAIN" \
+       -n 8.8.8.8 -n 1.1.1.1 \
+       --cycles 1 --max-rt 300 --min-success 0.95 \
+       --log-file "$DAILY_LOG" --quiet
+
+   nadzoring dns health "$DOMAIN" \
+       -o json --save "${LOG_DIR}/health_${TS}.json" --quiet
+
+   nadzoring dns benchmark --domain "$DOMAIN" --queries 5 \
+       -o json --save "${LOG_DIR}/benchmark_${TS}.json" --quiet
+
+   nadzoring dns monitor-report "$DAILY_LOG" \
+       -o html --save "${REPORT_DIR}/report_${TODAY}.html"
+
+   find "$LOG_DIR" -name "dns_monitor_*.jsonl" -mtime +30 -delete
+   find "$LOG_DIR" -name "health_*.json"       -mtime +7  -delete
+   find "$LOG_DIR" -name "benchmark_*.json"    -mtime +7  -delete

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -176,8 +176,8 @@ Check basic network reachability:
    from nadzoring.network_base.ping_address import ping_addr
 
    # Works with IPs, hostnames, and full URLs
-   reachable = ping_addr("8.8.8.8")          # True
-   reachable = ping_addr("https://google.com") # True — URL is normalised automatically
+   reachable = ping_addr("8.8.8.8")
+   reachable = ping_addr("https://google.com")
 
 ----
 
@@ -374,7 +374,7 @@ Find the fastest DNS resolver for your location:
        servers=["8.8.8.8", "1.1.1.1", "9.9.9.9"],
        queries=10,
    )
-   for r in results:  # sorted fastest-first
+   for r in results:
        print(f"{r['server']}: avg={r['avg_response_time']:.1f}ms  ok={r['success_rate']}%")
 
 ----
@@ -461,3 +461,116 @@ Getting Help
    nadzoring dns reverse --help
    nadzoring network-base port-scan --help
    nadzoring arp monitor-spoofing --help
+
+----
+
+14. Continuous DNS Monitoring
+-------------------------------
+
+The ``dns monitor`` command runs a persistent loop that tracks health and
+performance over time, fires alerts when thresholds are breached, and logs
+everything to a structured JSONL file.
+
+.. code-block:: bash
+
+   # Monitor with default servers (Google + Cloudflare), save log
+   nadzoring dns monitor example.com \
+       --interval 60 \
+       --log-file dns_monitor.jsonl
+
+   # Strict thresholds — alert above 150 ms or below 99 % success
+   nadzoring dns monitor example.com \
+       -n 8.8.8.8 -n 1.1.1.1 -n 9.9.9.9 \
+       --interval 30 \
+       --max-rt 150 --min-success 0.99 \
+       --log-file dns_monitor.jsonl
+
+   # Run exactly 10 cycles and save a JSON report (great for CI)
+   nadzoring dns monitor example.com --cycles 10 -o json --save report.json
+
+   # Quiet mode for cron / systemd
+   nadzoring dns monitor example.com \
+       --quiet --log-file /var/log/nadzoring/dns_monitor.jsonl
+
+After Ctrl-C (or after ``--cycles`` completes), a statistical summary is
+printed automatically.
+
+**Analyse the log later:**
+
+.. code-block:: bash
+
+   nadzoring dns monitor-report dns_monitor.jsonl
+   nadzoring dns monitor-report dns_monitor.jsonl --server 8.8.8.8 -o json
+
+**Python API — embed in your own script:**
+
+.. code-block:: python
+
+   from nadzoring.dns_lookup.monitor import AlertEvent, DNSMonitor, MonitorConfig
+
+
+   def my_alert_handler(alert: AlertEvent) -> None:
+       print(f"ALERT [{alert.alert_type}]: {alert.message}")
+
+
+   config = MonitorConfig(
+       domain="example.com",
+       nameservers=["8.8.8.8", "1.1.1.1"],
+       interval=60.0,
+       queries_per_sample=3,
+       max_response_time_ms=300.0,
+       min_success_rate=0.95,
+       log_file="dns_monitor.jsonl",
+       alert_callback=my_alert_handler,
+   )
+
+   monitor = DNSMonitor(config)
+   monitor.run()
+   print(monitor.report())
+
+**Scheduling with systemd (recommended for production):**
+
+.. code-block:: bash
+
+   # Create /etc/systemd/system/nadzoring-dns-monitor.service
+   # then:
+   sudo systemctl enable --now nadzoring-dns-monitor
+   sudo journalctl -u nadzoring-dns-monitor -f
+
+See :doc:`monitoring` for the full systemd unit file, cron setup, trend
+analysis examples, and alert integration patterns.
+
+----
+
+15. Error Handling Patterns
+-----------------------------
+
+Every public Python API function returns structured errors rather than
+raising exceptions, making it safe to use in automation scripts:
+
+.. code-block:: python
+
+   from nadzoring.dns_lookup.utils import resolve_with_timer
+   from nadzoring.dns_lookup.reverse import reverse_dns
+   from nadzoring.dns_lookup.health import health_check_dns
+
+   # resolve_with_timer never raises — check the "error" field
+   result = resolve_with_timer("example.com", "A", timeout=3.0)
+   if result["error"]:
+       # possible: 'Domain does not exist', 'Query timeout', 'No A records'
+       print("DNS error:", result["error"])
+   else:
+       print("Records:", result["records"])
+       print("Response time:", result["response_time"], "ms")
+
+   # reverse_dns — same pattern
+   r = reverse_dns("8.8.8.8")
+   hostname = r["hostname"] or f"[{r['error']}]"
+
+   # health_check_dns always returns a complete dict
+   health = health_check_dns("example.com")
+   if health["status"] == "unhealthy":
+       for issue in health["issues"]:
+           print("CRITICAL:", issue)
+   for warning in health["warnings"]:
+       print("WARN:", warning)

--- a/src/nadzoring/commands/dns_commands.py
+++ b/src/nadzoring/commands/dns_commands.py
@@ -20,6 +20,7 @@ from nadzoring.dns_lookup import (
 )
 from nadzoring.dns_lookup.compare import ServerComparisonResult
 from nadzoring.dns_lookup.health import DetailedCheckResult, HealthCheckResult
+from nadzoring.dns_lookup.monitor import AlertEvent, DNSMonitor, MonitorConfig, load_log
 from nadzoring.dns_lookup.types import BenchmarkResult, DNSResult, PoisoningCheckResult
 from nadzoring.logger import get_logger
 from nadzoring.utils.decorators import common_cli_options
@@ -34,6 +35,8 @@ from nadzoring.utils.formatters import (
 logger: Logger = get_logger(__name__)
 
 _QUERYABLE_RECORD_TYPES: list[str] = [t for t in RECORD_TYPES if t != "PTR"]
+
+_DEFAULT_NAMESERVERS: tuple[str, str] = ("8.8.8.8", "1.1.1.1")
 
 _RECORD_TYPE_CHOICE: Choice[str] = click.Choice(
     ["A", "AAAA", "CNAME", "MX", "NS", "TXT", "ALL"],
@@ -88,6 +91,259 @@ def _make_pbar(
 @click.group(name="dns")
 def dns_group() -> None:
     """DNS lookup and analysis commands."""
+
+
+@dns_group.command(name="monitor")
+@common_cli_options(include_quiet=True)
+@click.argument("domain", required=True)
+@click.option(
+    "--nameservers",
+    "-n",
+    multiple=True,
+    help="DNS server IP to monitor (repeatable).",
+)
+@click.option(
+    "--interval",
+    "-i",
+    type=float,
+    default=60.0,
+    show_default=True,
+    help="Seconds between monitoring cycles.",
+)
+@click.option(
+    "--type",
+    "-t",
+    "record_type",
+    default="A",
+    show_default=True,
+    type=click.Choice(["A", "AAAA", "MX", "NS", "TXT"]),
+    help="DNS record type to query each cycle.",
+)
+@click.option(
+    "--queries",
+    "-q",
+    type=int,
+    default=3,
+    show_default=True,
+    help="Queries sent to each server per cycle.",
+)
+@click.option(
+    "--max-rt",
+    type=float,
+    default=500.0,
+    show_default=True,
+    help="Alert threshold: max average response time (ms).",
+)
+@click.option(
+    "--min-success",
+    type=float,
+    default=0.95,
+    show_default=True,
+    help="Alert threshold: minimum success rate (0-1).",
+)
+@click.option(
+    "--no-health",
+    is_flag=True,
+    help="Skip DNS health check each cycle (faster for high-frequency use).",
+)
+@click.option(
+    "--log-file",
+    "-l",
+    default=None,
+    help="JSONL file to append all cycle results to.",
+)
+@click.option(
+    "--cycles",
+    "-c",
+    type=int,
+    default=0,
+    show_default=True,
+    help="Stop after N cycles (0 = run indefinitely).",
+)
+def monitor_command(
+    domain: str,
+    nameservers: tuple[str, ...],
+    interval: float,
+    record_type: str,
+    queries: int,
+    max_rt: float,
+    min_success: float,
+    log_file: str | None,
+    cycles: int,
+    *,
+    no_health: bool,
+    quiet: bool,
+) -> list[dict[str, Any]]:
+    r"""
+    Continuously monitor DNS server health and performance over time.
+
+    Runs periodic check cycles against one or more DNS servers, tracking
+    response times, success rates, and DNS health scores. Fires alerts
+    when thresholds are breached and optionally persists all results to a
+    JSONL log file.
+
+    Args:
+        domain: Domain name to query on every cycle.
+        nameservers: DNS server IPs to monitor.
+        interval: Seconds between monitoring cycles.
+        record_type: DNS record type to query.
+        queries: Queries sent to each server per cycle.
+        max_rt: Alert threshold for average response time in ms.
+        min_success: Alert threshold for success rate (0-1).
+        log_file: Path to JSONL log file, or ``None``.
+        cycles: Number of cycles to run (0 = indefinite).
+        no_health: When ``True``, skip the DNS health check each cycle.
+        quiet: When ``True``, suppress all console output.
+
+    Returns:
+        List of cycle-result dictionaries for ``--output`` formatting.
+
+    Example:
+        .. code-block:: bash
+
+            nadzoring dns monitor example.com \\
+                -n 8.8.8.8 -n 1.1.1.1 \\
+                --interval 30 \\
+                --log-file dns_monitor.jsonl
+
+    """
+    servers = list(nameservers) if nameservers else list(_DEFAULT_NAMESERVERS)
+
+    def _alert_cb(alert: AlertEvent) -> None:
+        if not quiet:
+            click.secho(
+                f"  ⚠  [{alert.alert_type.upper()}] {alert.message}",
+                fg="red",
+                err=True,
+            )
+
+    config = MonitorConfig(
+        domain=domain,
+        nameservers=servers,
+        record_type=record_type,  # type: ignore[arg-type]
+        interval=interval,
+        queries_per_sample=queries,
+        max_response_time_ms=max_rt,
+        min_success_rate=min_success,
+        run_health_check=not no_health,
+        log_file=log_file,
+        alert_callback=_alert_cb,
+    )
+    monitor = DNSMonitor(config)
+
+    if cycles > 0:
+        results = monitor.run_cycles(cycles)
+    else:
+        monitor.run()
+        results = monitor.history()
+
+    if not quiet:
+        click.echo("\n" + monitor.report(), err=True)
+
+    return [c.to_dict() for c in results]
+
+
+@dns_group.command(name="monitor-report")
+@common_cli_options()
+@click.argument("log_file", required=True)
+@click.option(
+    "--server",
+    "-s",
+    default=None,
+    help="Filter statistics to a specific server IP.",
+)
+def monitor_report_command(
+    log_file: str,
+    server: str | None,
+) -> list[dict[str, Any]]:
+    r"""
+    Analyse a JSONL monitoring log and return aggregated statistics.
+
+    Args:
+        log_file: Path to the JSONL file produced by ``dns monitor``.
+        server: Optional server IP to filter statistics to.
+
+    Returns:
+        List of per-server statistic rows for ``--output`` formatting.
+
+    Raises:
+        click.ClickException: If the log file is missing or empty.
+
+    Example:
+        .. code-block:: bash
+
+            nadzoring dns monitor-report dns_monitor.jsonl
+            nadzoring dns monitor-report dns_monitor.jsonl -s 8.8.8.8
+            nadzoring dns monitor-report dns_monitor.jsonl \\
+                -o json --save report.json
+
+    """
+    try:
+        cycles = load_log(log_file)
+    except FileNotFoundError:
+        raise click.ClickException(f"Log file not found: {log_file}") from None
+
+    if not cycles:
+        raise click.ClickException("Log file is empty.")
+
+    return _aggregate_log(cycles, server)
+
+
+def _aggregate_log(
+    cycles: list[dict[str, Any]],
+    server_filter: str | None,
+) -> list[dict[str, Any]]:
+    """
+    Aggregate per-server statistics from raw cycle dictionaries.
+
+    Args:
+        cycles: List of cycle-result dictionaries from :func:`load_log`.
+        server_filter: When set, only include data for this server IP.
+
+    Returns:
+        List of aggregated per-server statistic rows.
+
+    """
+    rts: dict[str, list[float]] = {}
+    successes: dict[str, list[float]] = {}
+    alert_counts: dict[str, int] = {}
+
+    for cycle in cycles:
+        for s in cycle.get("samples", []):
+            srv: str = s.get("server", "unknown")
+            if server_filter and srv != server_filter:
+                continue
+            rts.setdefault(srv, [])
+            successes.setdefault(srv, [])
+            alert_counts.setdefault(srv, 0)
+            rt: float | None = s.get("avg_response_time_ms")
+            if rt is not None:
+                rts[srv].append(rt)
+            successes[srv].append(s.get("success_rate", 0.0))
+
+        for alert in cycle.get("alerts", []):
+            srv = alert.get("server", "unknown")
+            if server_filter and srv != server_filter:
+                continue
+            alert_counts[srv] = alert_counts.get(srv, 0) + 1
+
+    rows: list[dict[str, Any]] = []
+    for srv, rt_list in rts.items():
+        ok_list = successes.get(srv, [])
+        rows.append(
+            {
+                "server": srv,
+                "samples": len(rt_list),
+                "avg_rt_ms": f"{sum(rt_list) / len(rt_list):.2f}" if rt_list else "N/A",
+                "min_rt_ms": f"{min(rt_list):.2f}" if rt_list else "N/A",
+                "max_rt_ms": f"{max(rt_list):.2f}" if rt_list else "N/A",
+                "avg_success_pct": (
+                    f"{sum(ok_list) / len(ok_list) * 100:.1f}" if ok_list else "N/A"
+                ),
+                "total_alerts": alert_counts.get(srv, 0),
+            }
+        )
+    return rows
 
 
 @dns_group.command(name="resolve")

--- a/src/nadzoring/dns_lookup/monitor.py
+++ b/src/nadzoring/dns_lookup/monitor.py
@@ -1,0 +1,640 @@
+"""Continuous DNS server health and performance monitoring."""
+
+from __future__ import annotations
+
+import json
+import signal
+import time
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from statistics import mean, stdev
+from typing import Any
+
+from nadzoring.dns_lookup.benchmark import benchmark_single_server
+from nadzoring.dns_lookup.health import health_check_dns
+from nadzoring.dns_lookup.types import RecordType
+from nadzoring.dns_lookup.utils import resolve_with_timer
+from nadzoring.logger import get_logger
+
+logger = get_logger(__name__)
+
+_DEFAULT_DOMAIN = "google.com"
+_DEFAULT_INTERVAL = 60.0
+_DEFAULT_MAX_HISTORY = 1440
+_DEFAULT_MAX_RT_MS = 500.0
+_DEFAULT_MIN_SUCCESS = 0.95
+_DEFAULT_QUERIES = 3
+_DEFAULT_NAMESERVERS: tuple[str, ...] = ("8.8.8.8", "1.1.1.1")
+_HEALTHY_SCORE_THRESHOLD = 80.0
+
+
+@dataclass
+class MonitorConfig:
+    """
+    Configuration for a DNSMonitor instance.
+
+    Attributes:
+        domain: Domain name to query on every check cycle.
+        nameservers: DNS server IPs to monitor.
+        record_type: DNS record type to query.
+        interval: Seconds between successive check cycles.
+        queries_per_sample: Queries sent to each server per cycle.
+        max_response_time_ms: Alert threshold for average response time
+            in milliseconds.
+        min_success_rate: Alert threshold for success rate (0.0-1.0).
+        run_health_check: Whether to run a full health check each cycle.
+            Set to ``False`` for high-frequency monitoring.
+        max_history: Maximum cycle results kept in memory.
+        log_file: Path to a JSONL file where results are appended.
+            ``None`` disables file logging.
+        alert_callback: Callable invoked with an :class:`AlertEvent` on
+            every threshold breach.
+
+    Example:
+        >>> config = MonitorConfig(
+        ...     domain="example.com",
+        ...     nameservers=["8.8.8.8", "1.1.1.1"],
+        ...     interval=30.0,
+        ...     max_response_time_ms=200.0,
+        ...     log_file="dns_monitor.jsonl",
+        ... )
+
+    """
+
+    domain: str = _DEFAULT_DOMAIN
+    nameservers: list[str] = field(
+        default_factory=lambda: list(_DEFAULT_NAMESERVERS),
+    )
+    record_type: RecordType = "A"
+    interval: float = _DEFAULT_INTERVAL
+    queries_per_sample: int = _DEFAULT_QUERIES
+    max_response_time_ms: float = _DEFAULT_MAX_RT_MS
+    min_success_rate: float = _DEFAULT_MIN_SUCCESS
+    run_health_check: bool = True
+    max_history: int = _DEFAULT_MAX_HISTORY
+    log_file: str | None = None
+    alert_callback: Callable[[AlertEvent], None] | None = None
+
+
+@dataclass
+class ServerSample:
+    """
+    A single performance sample for one DNS server.
+
+    Attributes:
+        server: IP address of the queried DNS server.
+        timestamp: UTC timestamp of the measurement.
+        avg_response_time_ms: Average response time in milliseconds, or
+            ``None`` when all queries failed.
+        min_response_time_ms: Minimum observed response time, or ``None``.
+        max_response_time_ms: Maximum observed response time, or ``None``.
+        success_rate: Fraction of successful queries (0.0-1.0).
+        records: DNS records returned by the server.
+        error: Last error message, or ``None`` on success.
+
+    """
+
+    server: str
+    timestamp: datetime
+    avg_response_time_ms: float | None
+    min_response_time_ms: float | None
+    max_response_time_ms: float | None
+    success_rate: float
+    records: list[str]
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serialise to a JSON-compatible dictionary.
+
+        Returns:
+            Dictionary representation of this sample.
+
+        """
+        return {
+            "server": self.server,
+            "timestamp": self.timestamp.isoformat(),
+            "avg_response_time_ms": self.avg_response_time_ms,
+            "min_response_time_ms": self.min_response_time_ms,
+            "max_response_time_ms": self.max_response_time_ms,
+            "success_rate": self.success_rate,
+            "records": self.records,
+            "error": self.error,
+        }
+
+
+@dataclass
+class AlertEvent:
+    """
+    A threshold breach detected during a monitoring cycle.
+
+    Attributes:
+        server: IP address or domain of the offending target.
+        alert_type: One of ``"resolution_failure"``, ``"high_latency"``,
+            ``"low_success_rate"``, or ``"health_degraded"``.
+        message: Human-readable description of the breach.
+        value: Measured value that triggered the alert, or ``None``.
+        threshold: Configured threshold that was breached, or ``None``.
+        timestamp: UTC time the alert was raised.
+
+    """
+
+    server: str
+    alert_type: str
+    message: str
+    value: float | None
+    threshold: float | None
+    timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serialise to a JSON-compatible dictionary.
+
+        Returns:
+            Dictionary representation of this alert.
+
+        """
+        return {
+            "server": self.server,
+            "alert_type": self.alert_type,
+            "message": self.message,
+            "value": self.value,
+            "threshold": self.threshold,
+            "timestamp": self.timestamp.isoformat(),
+        }
+
+
+@dataclass
+class CycleResult:
+    """
+    Aggregated result of one monitoring cycle.
+
+    Attributes:
+        cycle: 1-based cycle counter.
+        timestamp: UTC timestamp when the cycle started.
+        domain: Domain that was queried.
+        samples: Per-server performance samples.
+        health_score: DNS health score 0-100, or ``None`` when disabled.
+        health_status: One of ``"healthy"``, ``"degraded"``,
+            ``"unhealthy"``, or ``None``.
+        alerts: Alert events raised during this cycle.
+
+    """
+
+    cycle: int
+    timestamp: datetime
+    domain: str
+    samples: list[ServerSample]
+    health_score: int | None = None
+    health_status: str | None = None
+    alerts: list[AlertEvent] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serialise to a JSON-compatible dictionary.
+
+        Returns:
+            Dictionary representation of this cycle result.
+
+        """
+        return {
+            "cycle": self.cycle,
+            "timestamp": self.timestamp.isoformat(),
+            "domain": self.domain,
+            "samples": [s.to_dict() for s in self.samples],
+            "health_score": self.health_score,
+            "health_status": self.health_status,
+            "alerts": [a.to_dict() for a in self.alerts],
+        }
+
+
+class DNSMonitor:
+    """
+    Continuously monitor DNS servers for health and performance.
+
+    Each cycle benchmarks every configured server, optionally runs a
+    full health check, evaluates thresholds, dispatches alerts, and
+    persists the result to a JSONL log file.
+
+    ``SIGINT`` and ``SIGTERM`` are handled gracefully: the loop finishes
+    the current cycle, then stops.
+
+    Args:
+        config: Monitoring configuration.
+
+    Example:
+        >>> config = MonitorConfig(
+        ...     domain="example.com",
+        ...     nameservers=["8.8.8.8", "1.1.1.1"],
+        ...     interval=60.0,
+        ...     log_file="dns_monitor.jsonl",
+        ... )
+        >>> monitor = DNSMonitor(config)
+        >>> monitor.run()
+
+    """
+
+    def __init__(self, config: MonitorConfig) -> None:
+        """
+        Initialize a DNSMonitor.
+
+        Args:
+            config (MonitorConfig): dns monitoring configuration
+
+        """
+        self.config = config
+        self._history: deque[CycleResult] = deque(maxlen=config.max_history)
+        self._running = False
+        self._cycle = 0
+        self._log_path: Path | None = Path(config.log_file) if config.log_file else None
+        signal.signal(signal.SIGINT, self._handle_signal)
+        signal.signal(signal.SIGTERM, self._handle_signal)
+
+    def run(self) -> None:
+        """
+        Start the blocking monitoring loop.
+
+        Runs until :meth:`stop` is called or the process receives
+        ``SIGINT`` / ``SIGTERM``.
+        """
+        self._running = True
+        logger.info(
+            "DNS monitor starting: domain=%s servers=%s interval=%.0fs",
+            self.config.domain,
+            self.config.nameservers,
+            self.config.interval,
+        )
+        print(
+            f"[nadzoring] Monitoring {self.config.domain}"
+            f" every {self.config.interval:.0f}s — Ctrl-C to stop",
+            flush=True,
+        )
+        while self._running:
+            self._tick()
+            if self._running:
+                self._interruptible_sleep(self.config.interval)
+        logger.info("DNS monitor stopped after %d cycles.", self._cycle)
+
+    def run_cycles(self, count: int) -> list[CycleResult]:
+        """
+        Run a fixed number of cycles and return the results.
+
+        Useful for CI pipelines, tests, and cron-based scheduling where
+        the caller controls the loop.
+
+        Args:
+            count: Number of cycles to execute.
+
+        Returns:
+            List of :class:`CycleResult` objects, one per executed cycle.
+
+        Example:
+            >>> results = monitor.run_cycles(10)
+            >>> print(len(results))
+            10
+
+        """
+        self._running = True
+        for i in range(count):
+            self._tick()
+            if not self._running:
+                break
+            if i < count - 1:
+                self._interruptible_sleep(self.config.interval)
+        self._running = False
+        return self.history()
+
+    def stop(self) -> None:
+        """Signal the monitoring loop to stop after the current cycle."""
+        self._running = False
+
+    def history(self) -> list[CycleResult]:
+        """
+        Return a snapshot of the in-memory monitoring history.
+
+        Returns:
+            List of :class:`CycleResult` objects, oldest first.
+
+        """
+        return list(self._history)
+
+    def report(self) -> str:
+        """
+        Return a human-readable session summary.
+
+        Computes per-server mean, stdev, min, and max response times,
+        overall success rates, and health score trends across the full
+        in-memory history.
+
+        Returns:
+            Multi-line string for printing or logging.
+
+        Example:
+            >>> monitor.run_cycles(5)
+            >>> print(monitor.report())
+
+        """
+        if not self._history:
+            return "No monitoring data collected yet."
+
+        lines = [
+            "=" * 60,
+            f"DNS Monitor Report — {self.config.domain}",
+            f"Cycles : {self._cycle}",
+            (
+                f"Range  : {self._history[0].timestamp.isoformat()}"
+                f" → {self._history[-1].timestamp.isoformat()}"
+            ),
+            "=" * 60,
+        ]
+        for server in self.config.nameservers:
+            lines.extend(self._server_report_lines(server))
+
+        health_scores = [
+            c.health_score for c in self._history if c.health_score is not None
+        ]
+        if health_scores:
+            lines += [
+                "",
+                f"Health (last) : {health_scores[-1]}",
+                f"Health (avg)  : {mean(health_scores):.1f}",
+                f"Health (min)  : {min(health_scores)}",
+            ]
+        lines.append("=" * 60)
+        return "\n".join(lines)
+
+    def _tick(self) -> None:
+        self._cycle += 1
+        result = self._build_cycle_result()
+        self._history.append(result)
+        self._append_log(result)
+        self._print_summary(result)
+
+    def _build_cycle_result(self) -> CycleResult:
+        ts = datetime.now(UTC)
+        samples = [self._sample_server(srv, ts) for srv in self.config.nameservers]
+        health_score, health_status = self._run_health_check()
+        alerts = evaluate_thresholds(samples, health_score, health_status, self.config)
+        self._dispatch_alerts(alerts)
+        return CycleResult(
+            cycle=self._cycle,
+            timestamp=ts,
+            domain=self.config.domain,
+            samples=samples,
+            health_score=health_score,
+            health_status=health_status,
+            alerts=alerts,
+        )
+
+    def _sample_server(self, server: str, ts: datetime) -> ServerSample:
+        try:
+            bench = benchmark_single_server(
+                server=server,
+                domain=self.config.domain,
+                record_type=self.config.record_type,
+                queries=self.config.queries_per_sample,
+                delay=0.0,
+            )
+            resolved = resolve_with_timer(
+                self.config.domain,
+                self.config.record_type,
+                server,
+            )
+            return ServerSample(
+                server=server,
+                timestamp=ts,
+                avg_response_time_ms=(
+                    bench["avg_response_time"] if bench["success_rate"] > 0 else None
+                ),
+                min_response_time_ms=bench["min_response_time"] or None,
+                max_response_time_ms=bench["max_response_time"] or None,
+                success_rate=bench["success_rate"] / 100.0,
+                records=resolved.get("records", []),
+                error=resolved.get("error"),
+            )
+        except Exception as exc:
+            logger.exception("Sampling failed for server %s", server)
+            return ServerSample(
+                server=server,
+                timestamp=ts,
+                avg_response_time_ms=None,
+                min_response_time_ms=None,
+                max_response_time_ms=None,
+                success_rate=0.0,
+                records=[],
+                error=str(exc),
+            )
+
+    def _run_health_check(self) -> tuple[int | None, str | None]:
+        if not self.config.run_health_check:
+            return None, None
+        try:
+            result = health_check_dns(
+                self.config.domain,
+                self.config.nameservers[0],
+            )
+            return result["score"], result["status"]
+        except Exception:
+            logger.warning("Health check failed on cycle %d", self._cycle)
+            return None, None
+
+    def _dispatch_alerts(self, alerts: list[AlertEvent]) -> None:
+        if not self.config.alert_callback or not alerts:
+            return
+        for alert in alerts:
+            try:
+                self.config.alert_callback(alert)
+            except Exception:
+                logger.warning("Alert callback raised on cycle %d", self._cycle)
+
+    def _append_log(self, result: CycleResult) -> None:
+        if self._log_path is None:
+            return
+        try:
+            with self._log_path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(result.to_dict(), ensure_ascii=False) + "\n")
+        except OSError:
+            logger.warning("Could not write to log file %s", self._log_path)
+
+    def _print_summary(self, result: CycleResult) -> None:
+        ts = result.timestamp.strftime("%H:%M:%S")
+        for i, s in enumerate(result.samples):
+            rt = f"{s.avg_response_time_ms:.1f}ms" if s.avg_response_time_ms else "N/A"
+            health = (
+                f"  health={result.health_score}/{result.health_status}"
+                if i == 0 and result.health_score is not None
+                else ""
+            )
+            print(
+                f"[{ts}] #{result.cycle:4d}  {s.server:15s}"
+                f"  rt={rt:8s}  ok={s.success_rate * 100:.0f}%{health}",
+                flush=True,
+            )
+        for alert in result.alerts:
+            print(f"  ⚠  [{alert.alert_type}] {alert.message}", flush=True)
+
+    def _interruptible_sleep(self, seconds: float) -> None:
+        deadline = time.monotonic() + seconds
+        while self._running and time.monotonic() < deadline:
+            time.sleep(min(1.0, deadline - time.monotonic()))
+
+    def _handle_signal(self, _signum: int, _frame: object) -> None:
+        print("\n[nadzoring] Stopping monitor…", flush=True)
+        self._running = False
+
+    def _server_report_lines(self, server: str) -> list[str]:
+        samples = [s for c in self._history for s in c.samples if s.server == server]
+        if not samples:
+            return []
+
+        rts = [s.avg_response_time_ms for s in samples if s.avg_response_time_ms]
+        success_rates = [s.success_rate for s in samples]
+        alert_count = sum(
+            1 for c in self._history for a in c.alerts if a.server == server
+        )
+        lines = [f"\nServer : {server}", f"  Samples : {len(samples)}"]
+        if rts:
+            sd = f" ± {stdev(rts):.2f}" if len(rts) > 1 else ""
+            lines += [
+                f"  Avg RT  : {mean(rts):.2f}ms{sd}",
+                f"  Min RT  : {min(rts):.2f}ms",
+                f"  Max RT  : {max(rts):.2f}ms",
+            ]
+        lines += [
+            f"  Success : {mean(success_rates) * 100:.1f}%",
+            f"  Alerts  : {alert_count}",
+        ]
+        return lines
+
+
+def evaluate_thresholds(
+    samples: list[ServerSample],
+    health_score: int | None,
+    health_status: str | None,
+    config: MonitorConfig,
+) -> list[AlertEvent]:
+    """
+    Evaluate samples against configured thresholds.
+
+    Args:
+        samples: Per-server samples from the current cycle.
+        health_score: DNS health score 0-100, or ``None``.
+        health_status: Health status string, or ``None``.
+        config: Monitor configuration holding the threshold values.
+
+    Returns:
+        List of :class:`AlertEvent` objects; empty when all metrics are
+        within configured thresholds.
+
+    """
+    alerts: list[AlertEvent] = []
+    ts = datetime.now(UTC)
+
+    for s in samples:
+        if s.success_rate == 0.0:
+            alerts.append(
+                AlertEvent(
+                    server=s.server,
+                    alert_type="resolution_failure",
+                    message=(
+                        f"[{s.server}] Complete failure for {config.domain}: {s.error}"
+                    ),
+                    value=0.0,
+                    threshold=config.min_success_rate,
+                    timestamp=ts,
+                )
+            )
+            continue
+
+        if (
+            s.avg_response_time_ms is not None
+            and s.avg_response_time_ms > config.max_response_time_ms
+        ):
+            alerts.append(
+                AlertEvent(
+                    server=s.server,
+                    alert_type="high_latency",
+                    message=(
+                        f"[{s.server}] Latency {s.avg_response_time_ms:.1f}ms"
+                        f" > {config.max_response_time_ms:.0f}ms"
+                    ),
+                    value=s.avg_response_time_ms,
+                    threshold=config.max_response_time_ms,
+                    timestamp=ts,
+                )
+            )
+
+        if s.success_rate < config.min_success_rate:
+            alerts.append(
+                AlertEvent(
+                    server=s.server,
+                    alert_type="low_success_rate",
+                    message=(
+                        f"[{s.server}] Success {s.success_rate * 100:.1f}%"
+                        f" < {config.min_success_rate * 100:.0f}%"
+                    ),
+                    value=s.success_rate,
+                    threshold=config.min_success_rate,
+                    timestamp=ts,
+                )
+            )
+
+    if health_status in ("degraded", "unhealthy"):
+        alerts.append(
+            AlertEvent(
+                server=config.domain,
+                alert_type="health_degraded",
+                message=(
+                    f"Health for {config.domain} is {health_status}"
+                    f" (score={health_score})"
+                ),
+                value=float(health_score) if health_score is not None else None,
+                threshold=_HEALTHY_SCORE_THRESHOLD,
+                timestamp=ts,
+            )
+        )
+
+    return alerts
+
+
+def load_log(path: str | Path) -> list[dict[str, Any]]:
+    """
+    Load a JSONL monitoring log written by :class:`DNSMonitor`.
+
+    Args:
+        path: Path to the ``.jsonl`` file.
+
+    Returns:
+        List of cycle-result dictionaries, one per non-empty line.
+
+    Raises:
+        FileNotFoundError: If *path* does not exist.
+
+    Example:
+        >>> cycles = load_log("dns_monitor.jsonl")
+        >>> rts = [
+        ...     s["avg_response_time_ms"]
+        ...     for c in cycles
+        ...     for s in c["samples"]
+        ...     if s["avg_response_time_ms"] is not None
+        ... ]
+        >>> print(f"Mean RT: {sum(rts) / len(rts):.2f}ms")
+
+    """
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Log file not found: {path}")
+    results: list[dict[str, Any]] = []
+    with p.open(encoding="utf-8") as fh:
+        for lineno, raw in enumerate(fh, 1):
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                results.append(json.loads(line))
+            except json.JSONDecodeError:
+                logger.warning("Skipping malformed line %d in %s", lineno, p)
+    return results

--- a/src/nadzoring/network_base/whois_lookup.py
+++ b/src/nadzoring/network_base/whois_lookup.py
@@ -52,7 +52,7 @@ def _run_whois_command(target: str) -> str | None:
         Raw WHOIS output string, or None if the command failed.
 
     """
-    os_name = system()
+    os_name: str = system()
     encoding: Literal["cp866", "utf-8"] = "cp866" if os_name == "Windows" else "utf-8"
 
     try:
@@ -121,7 +121,7 @@ def whois_lookup(target: str) -> dict[str, str | None]:
         'RESERVED-Internet Assigned Numbers Authority'
 
     """
-    raw = _run_whois_command(target)
+    raw: str | None = _run_whois_command(target)
     if raw is None:
         return {
             "target": target,
@@ -129,7 +129,7 @@ def whois_lookup(target: str) -> dict[str, str | None]:
             "error": "WHOIS lookup failed. Ensure 'whois' is installed.",
         }
 
-    parsed = _parse_whois_output(raw)
+    parsed: dict[str, str | None] = _parse_whois_output(raw)
     parsed["target"] = target
     parsed["type"] = "ip" if _is_ip(target) else "domain"
     return parsed

--- a/src/nadzoring/utils/formatters.py
+++ b/src/nadzoring/utils/formatters.py
@@ -32,10 +32,10 @@ _HTML_STYLES = """\
     .medium { color: orange; }
     .low { color: green; }"""
 
-_CRITICAL_TERMS: set[str] = {"CRITICAL", "HIGH", "POISONED", "ERROR", "NXDOMAIN"}
-_WARNING_TERMS: set[str] = {"MEDIUM", "WARNING", "MISMATCH", "TTL_DIFF"}
-_INFO_TERMS: set[str] = {"LOW", "INFO", "REFERENCE", "CLEAN"}
-_POSITIVE_TERMS: set[str] = {"yes", "up", "passed", "good", "healthy"}
+_CRITICAL_TERMS = {"CRITICAL", "HIGH", "POISONED", "ERROR", "NXDOMAIN"}
+_WARNING_TERMS = {"MEDIUM", "WARNING", "MISMATCH", "TTL_DIFF"}
+_INFO_TERMS = {"LOW", "INFO", "REFERENCE", "CLEAN"}
+_POSITIVE_TERMS = {"yes", "up", "passed", "good", "healthy"}
 
 
 def get_terminal_width() -> int:
@@ -109,8 +109,8 @@ def colorize_value(value: Any, *, no_color: bool = False) -> str:
     if no_color or not isinstance(value, str):
         return value_str
 
-    upper: str = value.upper()
-    lower: str = value.lower()
+    upper = value.upper()
+    lower = value.lower()
 
     if upper in _CRITICAL_TERMS:
         return click.style(value_str, fg="red", bold=True)
@@ -169,8 +169,8 @@ def print_results_table(
         if h in max_widths:
             max_widths[h] = w
 
-    borders: int = len(headers) * 3 + 1
-    available: int = term_width - borders
+    borders = len(headers) * 3 + 1
+    available = term_width - borders
 
     widths: list[int] = (
         [min_widths[h] for h in headers]
@@ -179,7 +179,7 @@ def print_results_table(
     )
 
     try:
-        output: str = tabulate(
+        output = tabulate(
             data,
             headers="keys",
             tablefmt=tablefmt,
@@ -216,12 +216,12 @@ def _calculate_column_widths(
         List of integer column widths in the same order as *headers*.
 
     """
-    total_min: Literal[0] | int = sum(min_widths.values())
+    total_min = sum(min_widths.values())
 
     if total_min >= available:
         return [min_widths[h] for h in headers]
 
-    extra: float = (available - total_min) / len(headers)
+    extra = (available - total_min) / len(headers)
     col_widths: dict[str, int] = {
         h: min(int(min_widths[h] + extra), max_widths[h]) for h in headers
     }
@@ -275,7 +275,7 @@ def _build_html_page(title: str, html_table: str) -> str:
         Complete HTML document as a string.
 
     """
-    timestamp: str = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
+    timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
     return f"""<!DOCTYPE html>
 <html>
 <head>
@@ -308,7 +308,7 @@ def print_html_table(
     if not data:
         return
 
-    html_table: str = tabulate(data, headers="keys", tablefmt="html")
+    html_table = tabulate(data, headers="keys", tablefmt="html")
 
     if not full_page:
         click.echo(html_table)
@@ -537,17 +537,17 @@ def format_dns_trace(trace_result: dict[str, Any]) -> list[dict[str, Any]]:
     hops: list[dict[str, Any]] = trace_result.get("hops", [])
 
     for i, hop in enumerate(hops):
-        response_time: Any | None = hop.get("response_time")
+        response_time = hop.get("response_time")
 
         if response_time is None:
             time_str = "timeout"
         elif isinstance(response_time, int | float):
-            time_str: str = f"{response_time:.2f}ms"
+            time_str = f"{response_time:.2f}ms"
         else:
             time_str = str(response_time)
 
         records = hop.get("records", [])
-        records_str: str | Any = (
+        records_str = (
             "\n".join(str(r) for r in records)
             if records
             else hop.get("error", "No records")
@@ -649,7 +649,7 @@ def format_dns_health(health_result: dict[str, Any]) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = [summary]
 
     for record_type, record_score in health_result.get("record_scores", {}).items():
-        status: Literal["BAD", "GOOD", "WARN"] = (
+        status = (
             "GOOD" if record_score >= 80 else "WARN" if record_score >= 50 else "BAD"
         )
         rows.append(
@@ -706,9 +706,7 @@ def format_dns_poisoning(  # noqa: C901
     cdn_owner = poisoning_result.get("cdn_owner", "Unknown")
     cdn_percentage = poisoning_result.get("cdn_percentage", 0)
 
-    status_text: Literal["CDN DETECTED", "POISONING CHECK"] = (
-        "CDN DETECTED" if cdn_detected else "POISONING CHECK"
-    )
+    status_text = "CDN DETECTED" if cdn_detected else "POISONING CHECK"
     formatted.append(
         {
             "section": "DNS ANALYSIS",
@@ -848,7 +846,7 @@ def format_dns_poisoning(  # noqa: C901
             inc_severity = inc["severity"].upper()
 
             if itype == "Cdn Variation":
-                note: str = (
+                note = (
                     f"CDN node variation - same provider: {inc.get('owner', 'Unknown')}"
                 )
             elif itype == "Record Mismatch":
@@ -869,7 +867,7 @@ def format_dns_poisoning(  # noqa: C901
 
     if poisoning_result.get("cdn_detected"):
         verdict = "CLEAN (CDN DETECTED)"
-        explanation: str = f"Different {cdn_owner} CDN nodes - normal behavior"
+        explanation = f"Different {cdn_owner} CDN nodes - normal behavior"
     elif not poisoning_result.get("poisoned"):
         verdict = "CLEAN"
         explanation = "No inconsistencies detected"


### PR DESCRIPTION
Update docs

and add commands:
```
  monitor         Continuously monitor DNS server health and performance...
  monitor-report  Analyse a JSONL monitoring log and return aggregated...
```

And improve docs