### PR TITLE
add error handling for dns resolution in _query_txt

### DIFF
--- a/src/nadzoring/security/email_security.py
+++ b/src/nadzoring/security/email_security.py
@@ -7,6 +7,7 @@ from logging import Logger
 from typing import Any
 
 import dns.resolver
+from dns.resolver import Answer
 
 from nadzoring.logger import get_logger
 
@@ -132,8 +133,11 @@ def _query_txt(name: str) -> list[str]:
         List of complete TXT record strings, one entry per DNS record.
 
     """
-    answers = dns.resolver.resolve(name, "TXT", lifetime=5)
-    return [b"".join(r.strings).decode("utf-8", errors="replace") for r in answers]
+    try:
+        answers: Answer = dns.resolver.resolve(name, "TXT", lifetime=5)
+        return [b"".join(r.strings).decode("utf-8", errors="replace") for r in answers]
+    except Exception:
+        logger.debug("dnspython TXT lookup failed for %s", name)
 
     try:
         output: str = subprocess.check_output(  # noqa: S603


### PR DESCRIPTION
This PR is assigned with #20 

```python
    answers = dns.resolver.resolve(name, "TXT", lifetime=5)
    return [b"".join(r.strings).decode("utf-8", errors="replace") for r in answers]
```

fix to:

```python
    try:
        answers = dns.resolver.resolve(name, "TXT", lifetime=5)
        return [b"".join(r.strings).decode("utf-8", errors="replace") for r in answers]
    except Exception:
        logger.debug("dnspython TXT lookup failed for %s", name)
```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alexeev-prog/nadzoring/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
