### PR TITLE
feat: replace global socket timeout with per-socket timeouts for thread-safe concurrent scanning

### DIFF
--- a/src/nadzoring/security/subdomain_scan.py
+++ b/src/nadzoring/security/subdomain_scan.py
@@ -148,7 +148,10 @@ def _probe_subdomain(subdomain: str, timeout: float) -> dict[str, Any] | None:
 
     """
     try:
-        socket.setdefaulttimeout(timeout)
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(timeout)
+        sock.connect((subdomain, 80))
+        sock.close()
         ip: str = socket.gethostbyname(subdomain)
     except (TimeoutError, socket.gaierror):
         return None


### PR DESCRIPTION
fix from:

```python
    try:

        socket.setdefaulttimeout(timeout)

        ip: str = socket.gethostbyname(subdomain)
```

to:

```python
        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

        sock.settimeout(timeout)

        sock.connect((subdomain, 80))

        sock.close()

        ip: str = socket.gethostbyname(subdomain)
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alexeev-prog/nadzoring/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
