### PR TITLE
Fix wildcard matching in SAN DNS entries

### DIFF
--- a/src/nadzoring/security/check_website_ssl_cert.py
+++ b/src/nadzoring/security/check_website_ssl_cert.py
@@ -300,7 +300,13 @@ def check_domain_match(cert: Certificate, hostname: str) -> tuple[bool, list[str
         )
         if isinstance(san.value, SubjectAlternativeName):
             for name in san.value:
-                if isinstance(name, DNSName) and name.value == hostname:
+                if isinstance(name, DNSName) and (
+                    name.value == hostname
+                    or (
+                        name.value.startswith("*.")
+                        and _match_wildcard(name.value, hostname)
+                    )
+                ):
                     san_match = True
                     matches.append(f"DNS:{name.value}")
                 if isinstance(name, IPAddress) and str(name.value) == hostname:


### PR DESCRIPTION
This PR fix issue #24.

Currently, when checking domain matches against SAN DNS entries,
wildcard certificates (e.g., *.example.com) are only matched against
the exact wildcard string, not against subdomains. This breaks
validation for valid wildcard certificates where the wildcard is
only present in the SAN extension, which is the modern standard.

This fix extends the SAN DNS check to use the existing _match_wildcard
helper function for entries that start with a wildcard (*.), ensuring
that wildcard SAN entries properly match subdomains (e.g., 
*.example.com matches www.example.com).

From:

```python
                if isinstance(name, DNSName) and name.value == hostname:
```

to

```python
                if isinstance(name, DNSName) and (
                    name.value == hostname
                    or (
                        name.value.startswith("*.")
                        and _match_wildcard(name.value, hostname)
                    )
                ):

```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alexeev-prog/nadzoring/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
