### PR TITLE
Fix unreachable DNS fallback code in _get_dns_records

### DIFF
--- a/src/nadzoring/network_base/domain_info.py
+++ b/src/nadzoring/network_base/domain_info.py
@@ -74,37 +74,38 @@ def _get_dns_records(domain: str) -> dict[str, list[str]]:
             records[rtype] = [str(r) for r in answers]
         except Exception:
             logger.exception("Raised exception when get dns records")
-    return records
 
-    try:
-        a_records: list[
-            tuple[
-                AddressFamily,
-                SocketKind,
-                int,
-                str,
-                tuple[int, bytes] | tuple[str, int] | tuple[str, int, int, int],
-            ]
-        ] = socket.getaddrinfo(domain, None, socket.AF_INET)
-        if a_records:
-            records["A"] = list({s[4][0] for s in a_records})
-    except socket.gaierror:
-        pass
+    if "A" not in records:
+        try:
+            a_records: list[
+                tuple[
+                    AddressFamily,
+                    SocketKind,
+                    int,
+                    str,
+                    tuple[int, bytes] | tuple[str, int] | tuple[str, int, int, int],
+                ]
+            ] = socket.getaddrinfo(domain, None, socket.AF_INET)
+            if a_records:
+                records["A"] = list({s[4][0] for s in a_records})
+        except socket.gaierror:
+            pass
 
-    try:
-        aaaa_records: list[
-            tuple[
-                AddressFamily,
-                SocketKind,
-                int,
-                str,
-                tuple[int, bytes] | tuple[str, int] | tuple[str, int, int, int],
-            ]
-        ] = socket.getaddrinfo(domain, None, socket.AF_INET6)
-        if aaaa_records:
-            records["AAAA"] = list({s[4][0] for s in aaaa_records})
-    except socket.gaierror:
-        pass
+    if "AAAA" not in records:
+        try:
+            aaaa_records: list[
+                tuple[
+                    AddressFamily,
+                    SocketKind,
+                    int,
+                    str,
+                    tuple[int, bytes] | tuple[str, int] | tuple[str, int, int, int],
+                ]
+            ] = socket.getaddrinfo(domain, None, socket.AF_INET6)
+            if aaaa_records:
+                records["AAAA"] = list({s[4][0] for s in aaaa_records})
+        except socket.gaierror:
+            pass
 
     return records
 


### PR DESCRIPTION
This pr fixes #25 

The socket.getaddrinfo fallback for A/AAAA records was unreachable due to
an early return statement. This PR moves the return to the end and adds
conditional checks so the fallback executes when dns.resolver fails.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alexeev-prog/nadzoring/pull/28" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
