### PR TITLE
Fix misleading chain_valid field in SSL certificate check

### DIFF
--- a/src/nadzoring/security/check_website_ssl_cert.py
+++ b/src/nadzoring/security/check_website_ssl_cert.py
@@ -605,7 +605,9 @@ def check_ssl_certificate(
             - version: Certificate version
             - protocols: Protocol support information
             - chain_length: Number of certificates in chain (if verified)
-            - chain_valid: Boolean indicating chain validity (if verified)
+            - chain_valid: Boolean indicating if the certificate chain is properly
+                          constructed and valid (only meaningful when verification
+                          succeeded)
             - error: Error message if status is "error"
             - warning: Warning message if verification disabled
 
@@ -684,9 +686,13 @@ def check_ssl_certificate(
         protocols: dict[str, bool | list[str]] = check_protocols_and_ciphers(domain)
         result["protocols"] = protocols
 
-        if verify and cert_info.chain:
-            result["chain_length"] = len(cert_info.chain)
-            result["chain_valid"] = all(cert_info.chain)
+        if verify:
+            if cert_info.chain:
+                result["chain_length"] = len(cert_info.chain)
+                result["chain_valid"] = True
+            else:
+                result["chain_length"] = 0
+                result["chain_valid"] = False
 
     except Exception as e:
         result.update(


### PR DESCRIPTION
The `chain_valid` field in `check_ssl_certificate()` was incorrectly using
`all(cert_info.chain)` which always returns True for any non-empty list of
Certificate objects (since they're always truthy).

This fix:
- Removes the meaningless `all()` check
- Sets `chain_valid = True` when verification succeeds (as the SSL context
  has already validated the entire chain)
- Updates documentation to clarify the field's meaning
- Adds proper edge case handling

This makes the `chain_valid` field actually provide meaningful information
about certificate chain validity.

This PR fix issue #26 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alexeev-prog/nadzoring/pull/29" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
