### PR TITLE
add completions command group, tests and documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,8 +120,11 @@ The codebase follows strict conventions — study the existing source before wri
 # ✅ correct
 def resolve_hostname(hostname: str) -> str | None: ...
 
+
 # ❌ wrong
 from typing import Optional
+
+
 def resolve_hostname(hostname: str) -> Optional[str]: ...
 ```
 
@@ -166,6 +169,7 @@ Boolean flags and optional parameters must be keyword-only (after `*`):
 ```python
 # ✅ correct
 def run(target: str, *, max_hops: int = 30, timeout: float = 5.0) -> list[TraceHop]: ...
+
 
 # ❌ wrong
 def run(target: str, max_hops: int = 30, timeout: float = 5.0) -> list[TraceHop]: ...
@@ -221,6 +225,7 @@ When adding a new network or DNS function that may block, use `TimeoutConfig` fr
 ```python
 from nadzoring.utils.timeout import TimeoutConfig, timeout_context
 
+
 def my_network_operation(
     target: str,
     *,
@@ -250,7 +255,7 @@ Suppress ruff rules only where unavoidable, always with an inline comment explai
 
 ```python
 raw = check_output(  # noqa: S602
-    "ip route",     # noqa: S607
+    "ip route",  # noqa: S607
     shell=True,
     stderr=PIPE,
 )

--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ Beyond its technical strengths, Nadzoring is supported by an extensive, versione
     - [Installation](#installation)
   - [Usage](#usage)
     - [Global Options](#global-options)
+    - [Shell Completions](#shell-completions)
+      - [Bash](#bash)
+      - [Zsh](#zsh)
+      - [Fish](#fish)
+      - [PowerShell](#powershell)
+      - [Testing Completions](#testing-completions)
+      - [Manual Activation (without saving to profile)](#manual-activation-without-saving-to-profile)
+      - [Troubleshooting Completions](#troubleshooting-completions)
+      - [Completions Commands Reference](#completions-commands-reference)
     - [DNS Commands](#dns-commands)
       - [dns resolve](#dns-resolve)
       - [dns reverse](#dns-reverse)
@@ -207,6 +216,154 @@ These options work with every command:
 2. Generic `--timeout` (applies to both phases when phase-specific not set)
 3. Module-level defaults (shown above)
 
+### Shell Completions
+
+Nadzoring provides tab-completion support for **bash**, **zsh**, **fish**, and **PowerShell**. Enable it for your preferred shell using the commands below.
+
+#### Bash
+
+Add to `~/.bashrc` (or `~/.bash_profile` on macOS):
+
+```bash
+echo 'eval "$(nadzoring completion bash)"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+Alternative — save to a file and source it:
+
+```bash
+nadzoring completion bash > ~/.nadzoring-complete.bash
+echo 'source ~/.nadzoring-complete.bash' >> ~/.bashrc
+```
+
+#### Zsh
+
+Add to `~/.zshrc`:
+
+```bash
+echo 'eval "$(nadzoring completion zsh)"' >> ~/.zshrc
+source ~/.zshrc
+```
+
+Or save to a file in your `fpath`:
+
+```bash
+nadzoring completion zsh > "${fpath[1]}/_nadzoring"
+```
+
+#### Fish
+
+Save directly to Fish completions directory:
+
+```bash
+nadzoring completion fish > ~/.config/fish/completions/nadzoring.fish
+```
+
+Or source it temporarily:
+
+```bash
+nadzoring completion fish | source
+```
+
+#### PowerShell
+
+Add to your PowerShell profile (`$PROFILE`):
+
+```powershell
+nadzoring completion powershell >> $PROFILE
+```
+
+To reload the profile immediately:
+
+```powershell
+. $PROFILE
+```
+
+Or use it in the current session only:
+
+```powershell
+nadzoring completion powershell | Invoke-Expression
+```
+
+#### Testing Completions
+
+After installation, type `nadzoring ` followed by **TAB** to see available commands:
+
+```bash
+nadzoring [TAB]
+# Should show: arp  completion  dns  network-base  security
+```
+
+Type a command followed by space and **TAB** to see options:
+
+```bash
+nadzoring dns [TAB]
+# Should show: resolve  reverse  check  trace  compare  health  benchmark  poisoning  monitor
+```
+
+#### Manual Activation (without saving to profile)
+
+If you don't want to modify your shell profile, you can activate completions manually:
+
+```bash
+# Bash / Zsh
+source <(nadzoring completion bash)
+
+# Fish
+nadzoring completion fish | source
+
+# PowerShell
+nadzoring completion powershell | Invoke-Expression
+```
+
+#### Troubleshooting Completions
+
+**Completions not working?** Check these common issues:
+
+1. **Shell not reloaded** — restart your terminal or run `source ~/.bashrc` (bash) / `source ~/.zshrc` (zsh)
+2. **Wrong shell** — ensure you're using the correct completion command for your shell
+3. **PATH issue** — verify `nadzoring` is in your PATH: `which nadzoring`
+4. **Completion not registered** — run the activation command directly to see if there are any errors
+
+**Debugging bash completions:**
+
+```bash
+# Enable debug output
+set -x
+nadzoring [TAB]
+set +x
+```
+
+**Check if completion is registered:**
+
+```bash
+# Bash
+complete -p | grep nadzoring
+# Should output: complete -o nosort -F _nadzoring_completion nadzoring
+
+# Zsh
+echo $fpath | grep nadzoring
+```
+
+**Show installation hints:**
+
+```bash
+nadzoring completion hints bash      # For bash
+nadzoring completion hints zsh       # For zsh
+nadzoring completion hints fish      # For fish
+nadzoring completion hints powershell  # For PowerShell
+```
+
+#### Completions Commands Reference
+
+| Command | Description |
+|---------|-------------|
+| `nadzoring completion bash` | Generate bash completion script |
+| `nadzoring completion zsh` | Generate zsh completion script |
+| `nadzoring completion fish` | Generate fish completion script |
+| `nadzoring completion powershell` | Generate PowerShell completion script |
+| `nadzoring completion hints <shell>` | Show detailed installation hints |
+
 ---
 
 ### DNS Commands
@@ -262,17 +419,18 @@ if result["error"]:
     # "Query timeout"          — nameserver did not respond
     print("DNS error:", result["error"])
 else:
-    print(result["records"])       # ['93.184.216.34']
-    print(result["response_time"]) # milliseconds
+    print(result["records"])  # ['93.184.216.34']
+    print(result["response_time"])  # milliseconds
 
 # With TTL and custom nameserver
 result = resolve_with_timer(
-    "example.com", "MX",
+    "example.com",
+    "MX",
     nameserver="8.8.8.8",
     include_ttl=True,
 )
 print(result["records"])  # ['10 mail.example.com']
-print(result["ttl"])      # e.g. 3600
+print(result["ttl"])  # e.g. 3600
 
 # Custom timeout configuration
 config = TimeoutConfig(connect=3.0, read=8.0, lifetime=20.0)
@@ -323,7 +481,7 @@ if result["error"]:
     # "Invalid IP address: …"  — malformed input
     print("Lookup failed:", result["error"])
 else:
-    print(result["hostname"])       # 'dns.google'
+    print(result["hostname"])  # 'dns.google'
     print(result["response_time"])  # milliseconds
 
 # IPv6 reverse lookup
@@ -383,10 +541,10 @@ result = check_dns(
     validate_txt=True,
     timeout_config=config,
 )
-print(result["records"])        # {'MX': ['10 mail.example.com']}
-print(result["errors"])         # {'AAAA': 'No AAAA records'} — only failed types
-print(result["response_times"]) # per-type timing in ms
-print(result["validations"])    # {'mx': {'valid': True, 'issues': [], 'warnings': []}}
+print(result["records"])  # {'MX': ['10 mail.example.com']}
+print(result["errors"])  # {'AAAA': 'No AAAA records'} — only failed types
+print(result["response_times"])  # per-type timing in ms
+print(result["validations"])  # {'mx': {'valid': True, 'issues': [], 'warnings': []}}
 ```
 
 ---
@@ -737,12 +895,7 @@ from statistics import mean
 
 cycles = load_log("dns_monitor.jsonl")
 
-rts = [
-    s["avg_response_time_ms"]
-    for c in cycles
-    for s in c["samples"]
-    if s["avg_response_time_ms"] is not None
-]
+rts = [s["avg_response_time_ms"] for c in cycles for s in c["samples"] if s["avg_response_time_ms"] is not None]
 alerts = [a for c in cycles for a in c.get("alerts", [])]
 
 print(f"Cycles      : {len(cycles)}")
@@ -773,9 +926,9 @@ nadzoring network-base ping -o json github.com
 ```python
 from nadzoring.network_base.ping_address import ping_addr
 
-print(ping_addr("8.8.8.8"))            # True
-print(ping_addr("https://google.com")) # True — URLs are normalised automatically
-print(ping_addr("192.0.2.1"))          # False — unreachable
+print(ping_addr("8.8.8.8"))  # True
+print(ping_addr("https://google.com"))  # True — URLs are normalised automatically
+print(ping_addr("192.0.2.1"))  # False — unreachable
 
 # Note: ICMP may be blocked by firewalls even for reachable hosts
 ```
@@ -858,13 +1011,14 @@ else:
 # Validate IP format before resolving
 from nadzoring.utils.validators import validate_ip, validate_ipv4, validate_ipv6
 
-validate_ip("8.8.8.8")    # True
-validate_ipv4("::1")      # False
-validate_ipv6("::1")      # True
+validate_ip("8.8.8.8")  # True
+validate_ipv4("::1")  # False
+validate_ipv6("::1")  # True
 
 # Get router/gateway IP
 from nadzoring.network_base.router_ip import router_ip
-gateway = router_ip()         # '192.168.1.1' on most home networks
+
+gateway = router_ip()  # '192.168.1.1' on most home networks
 gateway6 = router_ip(ipv6=True)
 ```
 
@@ -889,14 +1043,14 @@ nadzoring network-base parse-url "postgresql://user:pass@localhost:5432/db"
 from nadzoring.network_base.parse_url import parse_url
 
 result = parse_url("https://user:pass@example.com:8080/path?key=value#frag")
-print(result["protocol"])   # 'https'
-print(result["hostname"])   # 'example.com'
-print(result["port"])       # 8080
-print(result["username"])   # 'user'
-print(result["password"])   # 'pass'
-print(result["path"])       # '/path'
+print(result["protocol"])  # 'https'
+print(result["hostname"])  # 'example.com'
+print(result["port"])  # 8080
+print(result["username"])  # 'user'
+print(result["password"])  # 'pass'
+print(result["path"])  # '/path'
 print(result["query_params"])  # [('key', 'value')]
-print(result["fragment"])   # 'frag'
+print(result["fragment"])  # 'frag'
 ```
 
 ---
@@ -957,10 +1111,10 @@ nadzoring network-base params -o json --save net_params.json
 from nadzoring.network_base.network_params import network_param
 
 info = network_param()
-print(info["IPv4 address"])        # '192.168.1.42'
-print(info["Router ip-address"])   # '192.168.1.1'
-print(info["MAC-address"])         # '00:11:22:33:44:55'
-print(info["Public IP address"])   # your external IP
+print(info["IPv4 address"])  # '192.168.1.42'
+print(info["Router ip-address"])  # '192.168.1.1'
+print(info["MAC-address"])  # '00:11:22:33:44:55'
+print(info["Public IP address"])  # your external IP
 ```
 
 ---
@@ -1083,9 +1237,9 @@ nadzoring network-base port-service -o json 8080 5432 27017
 ```python
 from nadzoring.network_base.service_on_port import get_service_on_port
 
-print(get_service_on_port(80))    # 'http'
-print(get_service_on_port(443))   # 'https'
-print(get_service_on_port(22))    # 'ssh'
+print(get_service_on_port(80))  # 'http'
+print(get_service_on_port(443))  # 'https'
+print(get_service_on_port(22))  # 'ssh'
 print(get_service_on_port(9999))  # 'unknown'
 ```
 
@@ -1116,7 +1270,7 @@ nadzoring network-base whois -o json --save whois_data.json github.com
 from nadzoring.network_base.whois_lookup import whois_lookup
 
 result = whois_lookup("example.com")
-print(result["registrar"])      # 'RESERVED-Internet Assigned Numbers Authority'
+print(result["registrar"])  # 'RESERVED-Internet Assigned Numbers Authority'
 print(result["creation_date"])  # '1995-08-14T04:00:00Z'
 print(result["expiry_date"])
 print(result["name_servers"])
@@ -1153,8 +1307,8 @@ print(info["whois"]["creation_date"])
 print(info["whois"]["expiry_date"])
 
 # Resolved IP addresses
-print(info["dns"]["ipv4"])    # '93.184.216.34'
-print(info["dns"]["ipv6"])    # '2606:2800:220:1:248:1893:25c8:1946'
+print(info["dns"]["ipv4"])  # '93.184.216.34'
+print(info["dns"]["ipv6"])  # '2606:2800:220:1:248:1893:25c8:1946'
 
 # DNS records by type
 for rtype, records in info["dns"]["records"].items():
@@ -1166,7 +1320,7 @@ if geo:
     print(f"{geo['city']}, {geo['country']}  ({geo['lat']}, {geo['lon']})")
 
 # Reverse DNS for the primary IP
-print(info["reverse_dns"])    # 'example.com' or None
+print(info["reverse_dns"])  # 'example.com' or None
 ```
 
 ---
@@ -1345,46 +1499,46 @@ config = TimeoutConfig(connect=3.0, read=8.0)
 # Verified check (full certificate chain validation)
 result = check_ssl_certificate("example.com", days_before=14, timeout_config=config)
 
-print(result["status"])          # 'valid' | 'warning' | 'expired' | 'error'
+print(result["status"])  # 'valid' | 'warning' | 'expired' | 'error'
 print(result["remaining_days"])  # e.g. 142
-print(result["expiry_date"])     # '2025-10-15T12:00:00+00:00'
-print(result["verification"])    # 'verified' | 'unverified' | 'failed'
+print(result["expiry_date"])  # '2025-10-15T12:00:00+00:00'
+print(result["verification"])  # 'verified' | 'unverified' | 'failed'
 
 # Subject and issuer dicts
-print(result["subject"]["CN"])   # 'example.com'
-print(result["issuer"]["CN"])    # 'DigiCert TLS RSA SHA256 2020 CA1'
-print(result["issuer"]["O"])     # 'DigiCert Inc'
+print(result["subject"]["CN"])  # 'example.com'
+print(result["issuer"]["CN"])  # 'DigiCert TLS RSA SHA256 2020 CA1'
+print(result["issuer"]["O"])  # 'DigiCert Inc'
 
 # Subject Alternative Names
 for san in result.get("san", []):
-    print(san)                   # 'DNS:example.com', 'DNS:www.example.com', ...
+    print(san)  # 'DNS:example.com', 'DNS:www.example.com', ...
 
 # Domain matching
-print(result["domain_match"])       # True
-print(result["matched_names"])      # ['DNS:example.com']
+print(result["domain_match"])  # True
+print(result["matched_names"])  # ['DNS:example.com']
 
 # Public key info
 key = result["public_key"]
-print(key["algorithm"])             # 'RSA' | 'EC' | 'Ed25519' | ...
-print(key.get("key_size"))          # 2048 (RSA/DSA)
-print(key.get("curve"))             # 'secp256r1' (EC)
-print(key["strength"])              # 'weak' | 'good' | 'strong'
+print(key["algorithm"])  # 'RSA' | 'EC' | 'Ed25519' | ...
+print(key.get("key_size"))  # 2048 (RSA/DSA)
+print(key.get("curve"))  # 'secp256r1' (EC)
+print(key["strength"])  # 'weak' | 'good' | 'strong'
 
 # Protocol support (TLSv1.0 – TLSv1.3)
 protos = result["protocols"]
-print(protos["supported"])          # ['TLSv1.2', 'TLSv1.3']
-print(protos["has_outdated"])       # False
+print(protos["supported"])  # ['TLSv1.2', 'TLSv1.3']
+print(protos["has_outdated"])  # False
 
 # Chain info (only when verify=True)
-print(result.get("chain_length"))   # 3
-print(result.get("chain_valid"))    # True
+print(result.get("chain_length"))  # 3
+print(result.get("chain_valid"))  # True
 
 # Simplified expiry-only check
 result = check_ssl_expiry("example.com")
 
 # Automatic fallback to unverified mode if chain check fails
 result = check_ssl_expiry_with_fallback("self-signed.badssl.com")
-print(result["verification"])       # 'unverified' when fallback was used
+print(result["verification"])  # 'unverified' when fallback was used
 ```
 
 ---
@@ -1446,9 +1600,9 @@ from nadzoring.utils.timeout import TimeoutConfig
 config = TimeoutConfig(connect=5.0, read=15.0)
 result = check_http_security_headers("https://example.com", timeout_config=config)
 
-print(result["url"])          # final URL after redirects
+print(result["url"])  # final URL after redirects
 print(result["status_code"])  # 200
-print(result["score"])        # 0–100 coverage score
+print(result["score"])  # 0–100 coverage score
 
 # Present security headers
 for header, value in result["present"].items():
@@ -1510,16 +1664,16 @@ print(result["overall_score"])  # e.g. 3
 
 # SPF analysis
 spf = result["spf"]
-print(spf["found"])             # True
-print(spf["record"])            # 'v=spf1 include:_spf.example.com ~all'
-print(spf["mechanisms"])        # ['include:_spf.example.com']
-print(spf["all_qualifier"])     # '~'  (softfail — recommended minimum)
+print(spf["found"])  # True
+print(spf["record"])  # 'v=spf1 include:_spf.example.com ~all'
+print(spf["mechanisms"])  # ['include:_spf.example.com']
+print(spf["all_qualifier"])  # '~'  (softfail — recommended minimum)
 for issue in spf["issues"]:
     print("  SPF issue:", issue)
 
 # DKIM analysis
 dkim = result["dkim"]
-print(dkim["found"])            # True
+print(dkim["found"])  # True
 print(dkim["selectors_checked"])  # list of 13 common selectors probed
 for selector, record in dkim["records"].items():
     print(f"  DKIM selector '{selector}': {record[:60]}...")
@@ -1528,13 +1682,13 @@ for issue in dkim["issues"]:
 
 # DMARC analysis
 dmarc = result["dmarc"]
-print(dmarc["found"])           # True
-print(dmarc["record"])          # 'v=DMARC1; p=reject; rua=mailto:...'
-print(dmarc["policy"])          # 'none' | 'quarantine' | 'reject'
+print(dmarc["found"])  # True
+print(dmarc["record"])  # 'v=DMARC1; p=reject; rua=mailto:...'
+print(dmarc["policy"])  # 'none' | 'quarantine' | 'reject'
 print(dmarc["subdomain_policy"])  # sp= tag value or None
-print(dmarc["pct"])             # percentage of messages the policy applies to
-print(dmarc["rua"])             # aggregate report addresses
-print(dmarc["ruf"])             # forensic report addresses
+print(dmarc["pct"])  # percentage of messages the policy applies to
+print(dmarc["rua"])  # aggregate report addresses
+print(dmarc["ruf"])  # forensic report addresses
 for issue in dmarc["issues"]:
     print("  DMARC issue:", issue)
 
@@ -1623,8 +1777,8 @@ results = scan_subdomains(
 )
 
 # Source values: 'ct_log' | 'brute_force'
-ct_found     = [r for r in results if r["source"] == "ct_log"]
-brute_found  = [r for r in results if r["source"] == "brute_force"]
+ct_found = [r for r in results if r["source"] == "ct_log"]
+brute_found = [r for r in results if r["source"] == "brute_force"]
 print(f"CT log: {len(ct_found)}  Brute-force: {len(brute_found)}")
 ```
 
@@ -1690,15 +1844,17 @@ config = TimeoutConfig(connect=3.0, read=10.0)
 # Create monitor for multiple domains
 monitor = SSLMonitor(
     domains=["example.com", "github.com", "cloudflare.com"],
-    interval=3600,   # seconds between cycles
+    interval=3600,  # seconds between cycles
     days_before=14,  # alert when fewer than 14 days remain
     timeout_config=config,
 )
+
 
 # Custom alert handler
 def on_alert(domain: str, message: str) -> None:
     print(f"ALERT  {domain}: {message}")
     # send to Slack, PagerDuty, email, etc.
+
 
 monitor.set_alert_callback(on_alert)
 
@@ -1746,12 +1902,7 @@ except ARPCacheRetrievalError as exc:
     print("Cannot read ARP cache:", exc)
 else:
     for entry in entries:
-        print(
-            f"{entry.ip_address}  "
-            f"{entry.mac_address or '(incomplete)'}  "
-            f"{entry.interface}  "
-            f"{entry.state.value}"
-        )
+        print(f"{entry.ip_address}  {entry.mac_address or '(incomplete)'}  {entry.interface}  {entry.state.value}")
 ```
 
 ---
@@ -1832,10 +1983,12 @@ for alert in alerts:
 stats = detector.get_stats()
 print(f"Processed: {stats['packets_processed']}  Alerts: {stats['alerts_generated']}")
 
+
 # Custom callback for integration with external systems
 def on_packet(packet, alert):
     if alert:
         print("ALERT:", alert)  # integrate with your alerting pipeline here
+
 
 detector.monitor(interface=None, count=0, timeout=0, packet_callback=on_packet)
 ```
@@ -1923,9 +2076,9 @@ from nadzoring.utils.timeout import TimeoutConfig, OperationTimeoutError, with_l
 
 # Create configuration
 config = TimeoutConfig(
-    connect=3.0,   # connection phase
-    read=8.0,      # read operations
-    lifetime=30.0, # total operation limit
+    connect=3.0,  # connection phase
+    read=8.0,  # read operations
+    lifetime=30.0,  # total operation limit
 )
 
 # Apply to a socket
@@ -1938,6 +2091,7 @@ try:
         result = long_running_operation()
 except OperationTimeoutError:
     print("Operation exceeded lifetime timeout")
+
 
 # Decorator for lifetime timeout
 @with_lifetime_timeout(config)
@@ -2031,9 +2185,9 @@ result = resolve_with_timer("example.com", "MX", include_ttl=True, timeout_confi
 if result["error"]:
     print("Error:", result["error"])
 else:
-    print(result["records"])       # ['10 mail.example.com']
-    print(result["ttl"])           # 3600
-    print(result["response_time"]) # 45.2
+    print(result["records"])  # ['10 mail.example.com']
+    print(result["ttl"])  # 3600
+    print(result["response_time"])  # 45.2
 
 # List built-in public servers
 servers = get_public_dns_servers()  # ['8.8.8.8', '1.1.1.1', ...]
@@ -2144,24 +2298,24 @@ config = TimeoutConfig(connect=3.0, read=10.0)
 # SSL/TLS certificate check
 result = check_ssl_certificate("example.com", days_before=14, timeout_config=config)
 print(result["status"], result["remaining_days"])
-print(result["protocols"]["supported"])   # ['TLSv1.2', 'TLSv1.3']
-print(result["public_key"]["strength"])   # 'good'
+print(result["protocols"]["supported"])  # ['TLSv1.2', 'TLSv1.3']
+print(result["public_key"]["strength"])  # 'good'
 
 # Fallback mode for self-signed / problematic certs
 result = check_ssl_expiry_with_fallback("self-signed.example.com")
 
 # HTTP security header audit
 headers = check_http_security_headers("https://example.com", timeout_config=config)
-print(headers["score"])     # 0–100
-print(headers["missing"])   # list of absent recommended headers
-print(headers["leaking"])   # {'Server': 'nginx/1.18.0'}
+print(headers["score"])  # 0–100
+print(headers["missing"])  # list of absent recommended headers
+print(headers["leaking"])  # {'Server': 'nginx/1.18.0'}
 
 # Email security (SPF / DKIM / DMARC)
 email = check_email_security("example.com")
-print(email["overall_score"])           # 0–3
-print(email["spf"]["all_qualifier"])    # '~' (softfail)
-print(email["dmarc"]["policy"])         # 'reject'
-print(email["all_issues"])              # aggregated issue list
+print(email["overall_score"])  # 0–3
+print(email["spf"]["all_qualifier"])  # '~' (softfail)
+print(email["dmarc"]["policy"])  # 'reject'
+print(email["all_issues"])  # aggregated issue list
 
 # Subdomain discovery
 subdomains = scan_subdomains(
@@ -2641,12 +2795,7 @@ config = MonitorConfig(
 monitor = DNSMonitor(config)
 history = monitor.run_cycles(6)
 
-rts = [
-    s.avg_response_time_ms
-    for c in history
-    for s in c.samples
-    if s.avg_response_time_ms is not None
-]
+rts = [s.avg_response_time_ms for c in history for s in c.samples if s.avg_response_time_ms is not None]
 print(f"Mean RT: {mean(rts):.1f}ms")
 print(monitor.report())
 ```
@@ -2658,12 +2807,7 @@ from nadzoring.dns_lookup.monitor import load_log
 from statistics import mean
 
 cycles = load_log("dns_monitor.jsonl")
-rts = [
-    s["avg_response_time_ms"]
-    for c in cycles
-    for s in c["samples"]
-    if s["avg_response_time_ms"] is not None
-]
+rts = [s["avg_response_time_ms"] for c in cycles for s in c["samples"] if s["avg_response_time_ms"] is not None]
 alerts = [a for c in cycles for a in c.get("alerts", [])]
 print(f"Cycles: {len(cycles)}  Mean RT: {mean(rts):.1f}ms  Alerts: {len(alerts)}")
 ```

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -169,8 +169,185 @@ Use one of the following approaches:
 
 ----
 
+Shell Completions
+-----------------
+
+Nadzoring provides tab-completion support for **bash**, **zsh**, **fish**, and
+**PowerShell**. Enable it for your preferred shell using the commands below.
+
+Bash
+~~~~
+
+Add to ``~/.bashrc`` (or ``~/.bash_profile`` on macOS):
+
+.. code-block:: bash
+
+   echo 'eval "$(nadzoring completion bash)"' >> ~/.bashrc
+   source ~/.bashrc
+
+Alternative — save to a file and source it:
+
+.. code-block:: bash
+
+   nadzoring completion bash > ~/.nadzoring-complete.bash
+   echo 'source ~/.nadzoring-complete.bash' >> ~/.bashrc
+
+Zsh
+~~~
+
+Add to ``~/.zshrc``:
+
+.. code-block:: bash
+
+   echo 'eval "$(nadzoring completion zsh)"' >> ~/.zshrc
+   source ~/.zshrc
+
+Or save to a file in your ``fpath``:
+
+.. code-block:: bash
+
+   nadzoring completion zsh > "${fpath[1]}/_nadzoring"
+
+Fish
+~~~~
+
+Save directly to Fish completions directory:
+
+.. code-block:: bash
+
+   nadzoring completion fish > ~/.config/fish/completions/nadzoring.fish
+
+Or source it temporarily:
+
+.. code-block:: bash
+
+   nadzoring completion fish | source
+
+PowerShell
+~~~~~~~~~~
+
+Add to your PowerShell profile (``$PROFILE``):
+
+.. code-block:: powershell
+
+   nadzoring completion powershell >> $PROFILE
+
+To reload the profile immediately:
+
+.. code-block:: powershell
+
+   . $PROFILE
+
+Or use it in the current session only:
+
+.. code-block:: powershell
+
+   nadzoring completion powershell | Invoke-Expression
+
+Testing Completions
+~~~~~~~~~~~~~~~~~~~
+
+After installation, type ``nadzoring `` followed by **TAB** to see available
+commands:
+
+.. code-block:: bash
+
+   nadzoring [TAB]
+   # Should show: arp  completion  dns  network-base  security
+
+Type a command followed by space and **TAB** to see options:
+
+.. code-block:: bash
+
+   nadzoring dns [TAB]
+   # Should show: resolve  reverse  check  trace  compare  health  benchmark  poisoning  monitor
+
+Manual Activation (without saving to profile)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you don't want to modify your shell profile, you can activate completions
+manually:
+
+.. code-block:: bash
+
+   # Bash / Zsh
+   source <(nadzoring completion bash)
+
+   # Fish
+   nadzoring completion fish | source
+
+   # PowerShell
+   nadzoring completion powershell | Invoke-Expression
+
+Troubleshooting Completions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Completions not working?** Check these common issues:
+
+1. **Shell not reloaded** — restart your terminal or run
+   ``source ~/.bashrc`` (bash) / ``source ~/.zshrc`` (zsh)
+
+2. **Wrong shell** — ensure you're using the correct completion command for
+   your shell
+
+3. **PATH issue** — verify ``nadzoring`` is in your PATH: ``which nadzoring``
+
+4. **Completion not registered** — run the activation command directly to see
+   if there are any errors
+
+**Debugging bash completions:**
+
+.. code-block:: bash
+
+   # Enable debug output
+   set -x
+   nadzoring [TAB]
+   set +x
+
+**Check if completion is registered:**
+
+.. code-block:: bash
+
+   # Bash
+   complete -p | grep nadzoring
+   # Should output: complete -o nosort -F _nadzoring_completion nadzoring
+
+   # Zsh
+   echo $fpath | grep nadzoring
+
+**Show installation hints:**
+
+.. code-block:: bash
+
+   nadzoring completion hints bash      # For bash
+   nadzoring completion hints zsh       # For zsh
+   nadzoring completion hints fish      # For fish
+   nadzoring completion hints powershell  # For PowerShell
+
+Completions Commands Reference
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Command
+     - Description
+   * - ``nadzoring completion bash``
+     - Generate bash completion script
+   * - ``nadzoring completion zsh``
+     - Generate zsh completion script
+   * - ``nadzoring completion fish``
+     - Generate fish completion script
+   * - ``nadzoring completion powershell``
+     - Generate PowerShell completion script
+   * - ``nadzoring completion hints <shell>``
+     - Show detailed installation hints
+
+----
+
 Verifying the Installation
-----------------------------
+--------------------------
 
 Run a quick smoke test after installing:
 
@@ -202,3 +379,6 @@ Run a quick smoke test after installing:
 
    # Test timeout configuration (slow operation will abort)
    nadzoring dns resolve --timeout 2 google.com
+
+   # Test shell completions (if enabled)
+   nadzoring [TAB]

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,9 +1,7 @@
 import nox
 
-python_versions = ["3.12", "3.13", "3.14"]
 
-
-@nox.session(python=python_versions, venv_backend="uv")
+@nox.session(venv_backend="uv")
 def test(session):
     """Run tests on specified Python versions with coverage."""
     session.run_always("uv", "sync", "--all-groups", external=True)

--- a/src/nadzoring/cli.py
+++ b/src/nadzoring/cli.py
@@ -2,8 +2,7 @@
 
 import click
 
-from nadzoring.commands import arp_group, dns_group, network_group, security_group
-from nadzoring.commands.completions_commands import completion_group
+from nadzoring.commands import arp_group, completion_group, dns_group, network_group, security_group
 
 
 @click.group()

--- a/src/nadzoring/cli.py
+++ b/src/nadzoring/cli.py
@@ -3,6 +3,7 @@
 import click
 
 from nadzoring.commands import arp_group, dns_group, network_group, security_group
+from nadzoring.commands.completions_commands import completion_group
 
 
 @click.group()
@@ -14,6 +15,7 @@ cli.add_command(network_group)
 cli.add_command(dns_group)
 cli.add_command(arp_group)
 cli.add_command(security_group)
+cli.add_command(completion_group)
 
 
 def main() -> None:

--- a/src/nadzoring/commands/__init__.py
+++ b/src/nadzoring/commands/__init__.py
@@ -1,8 +1,15 @@
 """Command modules initialization."""
 
 from nadzoring.commands.arp_commands import arp_group
+from nadzoring.commands.completions_commands import completion_group
 from nadzoring.commands.dns_commands import dns_group
 from nadzoring.commands.network_commands import network_group
 from nadzoring.commands.security_commands import security_group
 
-__all__: list[str] = ["arp_group", "dns_group", "network_group", "security_group"]
+__all__: list[str] = [
+    "arp_group",
+    "completion_group",
+    "dns_group",
+    "network_group",
+    "security_group",
+]

--- a/src/nadzoring/commands/completions_commands.py
+++ b/src/nadzoring/commands/completions_commands.py
@@ -1,15 +1,5 @@
-"""Shell completion support for the nadzoring CLI.
+"""Shell completion support for the nadzoring CLI."""
 
-Provides completion commands for bash, zsh, fish, and PowerShell shells.
-Each shell has its own dedicated command that emits the appropriate shell
-integration script.
-
-Typical usage (end-user):
-    nadzoring completion bash >> ~/.bashrc
-    nadzoring completion zsh >> ~/.zshrc
-    nadzoring completion fish > ~/.config/fish/completions/nadzoring.fish
-    nadzoring completion powershell >> $PROFILE
-"""
 
 from __future__ import annotations
 

--- a/src/nadzoring/commands/completions_commands.py
+++ b/src/nadzoring/commands/completions_commands.py
@@ -1,14 +1,12 @@
 """Shell completion support for the nadzoring CLI."""
 
-
 from __future__ import annotations
 
+import os
+
 import click
-from click.shell_completion import (
-    ShellComplete,
-    add_completion_class,
-    get_completion_class,
-)
+from click.parser import split_arg_string
+from click.shell_completion import CompletionItem, ShellComplete, add_completion_class, get_completion_class
 
 _SOURCE_POWERSHELL: str = """\
 Register-ArgumentCompleter -Native -CommandName %(prog_name)s -ScriptBlock {
@@ -58,8 +56,40 @@ class PowerShellComplete(ShellComplete):
         """
         return self.prog_name.replace("-", "_")
 
+    def get_completion_args(self) -> tuple[list[str], str]:
+        """Extract completion arguments from PowerShell environment.
 
-# Register the custom PowerShell completion class
+        Parses COMP_WORDS and COMP_CWORD environment variables set by the
+        PowerShell completion script to reconstruct the command line state.
+
+        Returns:
+            A tuple containing (args, incomplete) where args is the list of
+            completed arguments and incomplete is the current word being completed.
+        """
+        cwords_str = os.environ.get("COMP_WORDS", "")
+        cwords = split_arg_string(cwords_str)
+        cword = int(os.environ.get("COMP_CWORD", "0"))
+
+        args = cwords[1:cword]
+        incomplete = cwords[cword] if cword < len(cwords) else ""
+        return args, incomplete
+
+    def format_completion(self, item: CompletionItem) -> str:
+        """Format a completion item for PowerShell consumption.
+
+        Formats completions as comma-separated values where the first element
+        is the completion type and the second is the value. This matches the
+        parsing logic in the PowerShell completion script.
+
+        Args:
+            item: The completion item to format.
+
+        Returns:
+            A comma-separated string in the format "type,value".
+        """
+        return f"{item.type},{item.value}"
+
+
 add_completion_class(PowerShellComplete, name="powershell")
 
 

--- a/src/nadzoring/commands/completions_commands.py
+++ b/src/nadzoring/commands/completions_commands.py
@@ -1,0 +1,255 @@
+"""Shell completion support for the nadzoring CLI.
+
+Provides completion commands for bash, zsh, fish, and PowerShell shells.
+Each shell has its own dedicated command that emits the appropriate shell
+integration script.
+
+Typical usage (end-user):
+    nadzoring completion bash >> ~/.bashrc
+    nadzoring completion zsh >> ~/.zshrc
+    nadzoring completion fish > ~/.config/fish/completions/nadzoring.fish
+    nadzoring completion powershell >> $PROFILE
+"""
+
+from __future__ import annotations
+
+import click
+from click.shell_completion import (
+    ShellComplete,
+    add_completion_class,
+    get_completion_class,
+)
+
+_SOURCE_POWERSHELL: str = """\
+Register-ArgumentCompleter -Native -CommandName %(prog_name)s -ScriptBlock {
+    param($wordToComplete, $commandAst, $cursorPosition)
+    $env:%(complete_var)s = "powershell_complete"
+    $env:COMP_WORDS = $commandAst.ToString()
+    $env:COMP_CWORD = $commandAst.CommandElements.Count - 1
+    $completions = & %(prog_name)s
+    $env:%(complete_var)s = ""
+    $completions | ForEach-Object {
+        $parts = $_ -split ","
+        if ($parts[0] -eq "plain") {
+            [System.Management.Automation.CompletionResult]::new(
+                $parts[1], $parts[1],
+                [System.Management.Automation.CompletionResultType]::ParameterValue,
+                $parts[1]
+            )
+        }
+    }
+}
+"""
+
+
+class PowerShellComplete(ShellComplete):
+    """Click completion backend for PowerShell (pwsh / Windows PowerShell).
+
+    Registered under the "powershell" shell name so that Click's env-var
+    dispatch mechanism can route completion requests correctly.
+
+    Attributes:
+        name: Shell identifier used as the command name.
+        source_template: Template string for the integration snippet.
+    """
+
+    name = "powershell"
+    source_template = _SOURCE_POWERSHELL
+
+    @property
+    def func_name(self) -> str:
+        """Returns a PowerShell-safe function/variable name.
+
+        Replaces hyphens with underscores so the generated snippet is valid
+        PowerShell syntax regardless of the program name.
+
+        Returns:
+            Sanitised program name suitable for PowerShell identifiers.
+        """
+        return self.prog_name.replace("-", "_")
+
+
+# Register the custom PowerShell completion class
+add_completion_class(PowerShellComplete, name="powershell")
+
+
+def _get_root_cli_and_prog_name(ctx: click.Context) -> tuple[click.BaseCommand, str]:
+    """Retrieves the root CLI command and program name from the context.
+
+    Args:
+        ctx: Click context object containing command information.
+
+    Returns:
+        A tuple containing (root_command, program_name).
+    """
+    root_ctx = ctx
+    while root_ctx.parent is not None:
+        root_ctx = root_ctx.parent
+
+    root_cli: click.BaseCommand = root_ctx.command
+    prog_name: str = root_ctx.info_name or "nadzoring"
+    return root_cli, prog_name
+
+
+def _generate_completion_script(
+    shell: str,
+    cli: click.BaseCommand,
+    prog_name: str,
+) -> str:
+    """Generates the shell integration script for the specified shell.
+
+    Args:
+        shell: Target shell name (bash, zsh, fish, or powershell).
+        cli: Root Click command group of the application.
+        prog_name: Binary name as invoked by the user.
+
+    Returns:
+        The complete shell script as a string.
+
+    Raises:
+        click.UsageError: If the specified shell is unsupported.
+    """
+    completion_class = get_completion_class(shell)
+    if completion_class is None:
+        raise click.UsageError(f"Shell '{shell}' is not supported. Supported shells: bash, zsh, fish, powershell")
+
+    complete_var: str = f"_{prog_name.upper().replace('-', '_')}_COMPLETE"
+    completer = completion_class(cli, {}, prog_name, complete_var)  # type: ignore[arg-type]
+    return completer.source()
+
+
+@click.group(name="completion")
+def completion_group() -> None:
+    """Generate shell completion scripts for various shells.
+
+    Each subcommand outputs a shell-specific completion script that can be
+    sourced or saved to enable tab-completion for the nadzoring CLI.
+    """
+
+
+@completion_group.command(name="bash")
+@click.pass_context
+def completion_bash(ctx: click.Context) -> None:
+    """Generate bash completion script.
+
+    Examples:
+        eval "$(nadzoring completion bash)"
+        or
+        nadzoring completion bash > ~/.nadzoring-complete.bash
+        echo 'source ~/.nadzoring-complete.bash' >> ~/.bashrc
+    """
+    root_cli, prog_name = _get_root_cli_and_prog_name(ctx)
+    script = _generate_completion_script("bash", root_cli, prog_name)
+    click.echo(script, nl=False)
+
+
+@completion_group.command(name="zsh")
+@click.pass_context
+def completion_zsh(ctx: click.Context) -> None:
+    """Generate zsh completion script.
+
+    Examples:
+        eval "$(nadzoring completion zsh)"
+        or
+        nadzoring completion zsh > "${fpath[1]}/_nadzoring"
+    """
+    root_cli, prog_name = _get_root_cli_and_prog_name(ctx)
+    script = _generate_completion_script("zsh", root_cli, prog_name)
+    click.echo(script, nl=False)
+
+
+@completion_group.command(name="fish")
+@click.pass_context
+def completion_fish(ctx: click.Context) -> None:
+    """Generate fish completion script.
+
+    Examples:
+        nadzoring completion fish | source
+        or
+        nadzoring completion fish > ~/.config/fish/completions/nadzoring.fish
+    """
+    root_cli, prog_name = _get_root_cli_and_prog_name(ctx)
+    script = _generate_completion_script("fish", root_cli, prog_name)
+    click.echo(script, nl=False)
+
+
+@completion_group.command(name="powershell")
+@click.pass_context
+def completion_powershell(ctx: click.Context) -> None:
+    """Generate PowerShell completion script.
+
+    Examples:
+        nadzoring completion powershell | Invoke-Expression
+        or
+        nadzoring completion powershell >> $PROFILE
+    """
+    root_cli, prog_name = _get_root_cli_and_prog_name(ctx)
+    script = _generate_completion_script("powershell", root_cli, prog_name)
+    click.echo(script, nl=False)
+
+
+@completion_group.command(name="hints")
+@click.argument("shell", type=click.Choice(["bash", "zsh", "fish", "powershell"]))
+def completion_hints(shell: str) -> None:
+    """Display installation hints for the specified shell.
+
+    Shows detailed instructions on how to install and enable completions
+    for the given shell.
+
+    Args:
+        shell: The shell to show hints for (bash, zsh, fish, or powershell).
+    """
+    hints = {
+        "bash": """
+Bash Installation Hints:
+-----------------------
+Option 1 (recommended):
+    echo 'eval "$(nadzoring completion bash)"' >> ~/.bashrc
+    source ~/.bashrc
+
+Option 2 (persistent file):
+    nadzoring completion bash > ~/.nadzoring-complete.bash
+    echo 'source ~/.nadzoring-complete.bash' >> ~/.bashrc
+
+Note: On macOS, use ~/.bash_profile instead of ~/.bashrc
+        """,
+        "zsh": """
+Zsh Installation Hints:
+----------------------
+Option 1 (recommended):
+    echo 'eval "$(nadzoring completion zsh)"' >> ~/.zshrc
+    source ~/.zshrc
+
+Option 2 (using fpath):
+    nadzoring completion zsh > "${fpath[1]}/_nadzoring"
+    # Then add to ~/.zshrc:
+    echo 'autoload -U compinit && compinit' >> ~/.zshrc
+        """,
+        "fish": """
+Fish Installation Hints:
+-----------------------
+Option 1 (temporary):
+    nadzoring completion fish | source
+
+Option 2 (permanent):
+    nadzoring completion fish > ~/.config/fish/completions/nadzoring.fish
+    # Completions will be loaded automatically on shell startup
+        """,
+        "powershell": """
+PowerShell Installation Hints:
+----------------------------
+Option 1 (current session):
+    nadzoring completion powershell | Invoke-Expression
+
+Option 2 (permanent - add to profile):
+    nadzoring completion powershell >> $PROFILE
+    # Reload profile:
+    . $PROFILE
+
+Note: $PROFILE path varies by PowerShell version and configuration.
+      Run '$PROFILE' to see your profile path.
+        """,
+    }
+
+    hint = hints.get(shell.lower(), "No hints available for this shell.")
+    click.echo(hint)

--- a/src/nadzoring/security/check_website_ssl_cert.py
+++ b/src/nadzoring/security/check_website_ssl_cert.py
@@ -132,8 +132,11 @@ class CertificateInfo:
             self._cert = x509.load_der_x509_certificate(der_cert, default_backend())
 
             self._chain = []
-            for der in ssock.get_verified_chain():
-                self._chain.append(x509.load_der_x509_certificate(der, default_backend()))
+            if hasattr(ssock, "get_verified_chain"):
+                for der in ssock.get_verified_chain():
+                    self._chain.append(x509.load_der_x509_certificate(der, default_backend()))
+            else:
+                self._chain.append(self._cert)
 
     def fetch_unverified(self) -> None:
         """

--- a/tests/test_commands/test_completions.py
+++ b/tests/test_commands/test_completions.py
@@ -1,0 +1,341 @@
+import pathlib
+from unittest.mock import MagicMock, patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from nadzoring.commands.completions_commands import (
+    _SOURCE_POWERSHELL,
+    PowerShellComplete,
+    _generate_completion_script,
+    _get_root_cli_and_prog_name,
+    completion_group,
+)
+
+
+class TestPowerShellComplete:
+    def test_name_attribute(self):
+        assert PowerShellComplete.name == "powershell"
+
+    def test_source_template(self):
+        assert PowerShellComplete.source_template == _SOURCE_POWERSHELL
+
+    def test_func_name_with_hyphens(self):
+        completer = PowerShellComplete(
+            cli=MagicMock(),
+            ctx_args={},
+            prog_name="my-app-name",
+            complete_var="TEST_VAR",
+        )
+        assert completer.func_name == "my_app_name"
+
+    def test_func_name_without_hyphens(self):
+        completer = PowerShellComplete(cli=MagicMock(), ctx_args={}, prog_name="myapp", complete_var="TEST_VAR")
+        assert completer.func_name == "myapp"
+
+    def test_func_name_empty(self):
+        completer = PowerShellComplete(cli=MagicMock(), ctx_args={}, prog_name="", complete_var="TEST_VAR")
+        assert completer.func_name == ""
+
+
+class TestGetRootCliAndProgName:
+    def test_single_level_context(self):
+        cli = click.Group(name="test")
+        ctx = click.Context(cli, info_name="testcli")
+
+        root_cli, prog_name = _get_root_cli_and_prog_name(ctx)
+
+        assert root_cli is cli
+        assert prog_name == "testcli"
+
+    def test_multi_level_context(self):
+        grandparent_cli = click.Group(name="grandparent")
+        parent_cli = click.Group(name="parent")
+        child_cli = click.Command(name="child")
+
+        grandparent_cli.add_command(parent_cli)
+        parent_cli.add_command(child_cli)
+
+        grandparent_ctx = click.Context(grandparent_cli, info_name="grandparent")
+        parent_ctx = click.Context(parent_cli, parent=grandparent_ctx, info_name="parent")
+        child_ctx = click.Context(child_cli, parent=parent_ctx, info_name="child")
+
+        root_cli, prog_name = _get_root_cli_and_prog_name(child_ctx)
+
+        assert root_cli is grandparent_cli
+        assert prog_name == "grandparent"
+
+    def test_info_name_none_defaults_to_nadzoring(self):
+        cli = click.Group()
+        ctx = click.Context(cli)
+
+        root_cli, prog_name = _get_root_cli_and_prog_name(ctx)
+
+        assert root_cli is cli
+        assert prog_name == "nadzoring"
+
+
+class TestGenerateCompletionScript:
+    def test_bash_shell(self):
+        cli = click.Group(name="test")
+        script = _generate_completion_script("bash", cli, "testprog")
+
+        assert "_TESTPROG_COMPLETE=bash_complete" in script
+        assert "complete" in script
+        assert "testprog" in script
+        assert "_testprog_completion" in script
+
+    def test_zsh_shell(self):
+        cli = click.Group(name="test")
+        script = _generate_completion_script("zsh", cli, "testprog")
+
+        assert "#compdef testprog" in script
+        assert "_TESTPROG_COMPLETE=zsh_complete" in script
+
+    def test_fish_shell(self):
+        cli = click.Group(name="test")
+        script = _generate_completion_script("fish", cli, "testprog")
+
+        assert "function _testprog_completion" in script
+        assert "complete" in script
+        assert "testprog" in script
+
+    def test_powershell_shell(self):
+        cli = click.Group(name="test")
+        script = _generate_completion_script("powershell", cli, "testprog")
+
+        assert "Register-ArgumentCompleter" in script
+        assert "testprog" in script
+        assert "_TESTPROG_COMPLETE" in script
+
+    def test_unsupported_shell_raises_error(self):
+        cli = click.Group(name="test")
+
+        with pytest.raises(click.UsageError) as exc_info:
+            _generate_completion_script("unsupported", cli, "testprog")
+
+        assert "Shell 'unsupported' is not supported" in str(exc_info.value)
+        assert "bash, zsh, fish, powershell" in str(exc_info.value)
+
+    def test_prog_name_with_hyphens_sanitized_in_var(self):
+        cli = click.Group(name="test")
+        script = _generate_completion_script("bash", cli, "test-prog-name")
+
+        assert "_TEST_PROG_NAME_COMPLETE" in script
+
+
+class TestCompletionGroupCommands:
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    def test_completion_bash(self, runner):
+        with patch("nadzoring.commands.completions_commands._get_root_cli_and_prog_name") as mock_get:
+            mock_cli = click.Group(name="nadzoring")
+            mock_get.return_value = (mock_cli, "nadzoring")
+
+            result = runner.invoke(completion_group, ["bash"])
+
+            assert result.exit_code == 0
+            assert "_NADZORING_COMPLETE=bash_complete" in result.output
+            assert "complete" in result.output
+            assert "nadzoring" in result.output
+            assert "_nadzoring_completion" in result.output
+
+    def test_completion_zsh(self, runner):
+        with patch("nadzoring.commands.completions_commands._get_root_cli_and_prog_name") as mock_get:
+            mock_cli = click.Group(name="nadzoring")
+            mock_get.return_value = (mock_cli, "nadzoring")
+
+            result = runner.invoke(completion_group, ["zsh"])
+
+            assert result.exit_code == 0
+            assert "#compdef nadzoring" in result.output
+            assert "_NADZORING_COMPLETE=zsh_complete" in result.output
+
+    def test_completion_fish(self, runner):
+        with patch("nadzoring.commands.completions_commands._get_root_cli_and_prog_name") as mock_get:
+            mock_cli = click.Group(name="nadzoring")
+            mock_get.return_value = (mock_cli, "nadzoring")
+
+            result = runner.invoke(completion_group, ["fish"])
+
+            assert result.exit_code == 0
+            assert "function _nadzoring_completion" in result.output
+            assert "complete" in result.output
+            assert "nadzoring" in result.output
+
+    def test_completion_powershell(self, runner):
+        with patch("nadzoring.commands.completions_commands._get_root_cli_and_prog_name") as mock_get:
+            mock_cli = click.Group(name="nadzoring")
+            mock_get.return_value = (mock_cli, "nadzoring")
+
+            result = runner.invoke(completion_group, ["powershell"])
+
+            assert result.exit_code == 0
+            assert "Register-ArgumentCompleter" in result.output
+            assert "CommandName nadzoring" in result.output
+            assert "_NADZORING_COMPLETE" in result.output
+
+    @patch("nadzoring.commands.completions_commands._generate_completion_script")
+    @patch("nadzoring.commands.completions_commands._get_root_cli_and_prog_name")
+    def test_completion_bash_calls_generate_script(self, mock_get, mock_generate, runner):
+        mock_cli = click.Group(name="nadzoring")
+        mock_get.return_value = (mock_cli, "nadzoring")
+        mock_generate.return_value = "mock script"
+
+        result = runner.invoke(completion_group, ["bash"])
+
+        assert result.exit_code == 0
+        assert result.output == "mock script"
+        mock_generate.assert_called_once_with("bash", mock_cli, "nadzoring")
+
+    @patch("nadzoring.commands.completions_commands._generate_completion_script")
+    @patch("nadzoring.commands.completions_commands._get_root_cli_and_prog_name")
+    def test_completion_zsh_calls_generate_script(self, mock_get, mock_generate, runner):
+        mock_cli = click.Group(name="nadzoring")
+        mock_get.return_value = (mock_cli, "nadzoring")
+        mock_generate.return_value = "mock script"
+
+        result = runner.invoke(completion_group, ["zsh"])
+
+        assert result.exit_code == 0
+        assert result.output == "mock script"
+        mock_generate.assert_called_once_with("zsh", mock_cli, "nadzoring")
+
+    @patch("nadzoring.commands.completions_commands._generate_completion_script")
+    @patch("nadzoring.commands.completions_commands._get_root_cli_and_prog_name")
+    def test_completion_fish_calls_generate_script(self, mock_get, mock_generate, runner):
+        mock_cli = click.Group(name="nadzoring")
+        mock_get.return_value = (mock_cli, "nadzoring")
+        mock_generate.return_value = "mock script"
+
+        result = runner.invoke(completion_group, ["fish"])
+
+        assert result.exit_code == 0
+        assert result.output == "mock script"
+        mock_generate.assert_called_once_with("fish", mock_cli, "nadzoring")
+
+    @patch("nadzoring.commands.completions_commands._generate_completion_script")
+    @patch("nadzoring.commands.completions_commands._get_root_cli_and_prog_name")
+    def test_completion_powershell_calls_generate_script(self, mock_get, mock_generate, runner):
+        mock_cli = click.Group(name="nadzoring")
+        mock_get.return_value = (mock_cli, "nadzoring")
+        mock_generate.return_value = "mock script"
+
+        result = runner.invoke(completion_group, ["powershell"])
+
+        assert result.exit_code == 0
+        assert result.output == "mock script"
+        mock_generate.assert_called_once_with("powershell", mock_cli, "nadzoring")
+
+
+class TestCompletionHintsCommand:
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    def test_completion_hints_bash(self, runner):
+        result = runner.invoke(completion_group, ["hints", "bash"])
+
+        assert result.exit_code == 0
+        assert "Bash Installation Hints:" in result.output
+        assert 'eval "$(nadzoring completion bash)"' in result.output
+        assert "~/.bashrc" in result.output
+
+    def test_completion_hints_zsh(self, runner):
+        result = runner.invoke(completion_group, ["hints", "zsh"])
+
+        assert result.exit_code == 0
+        assert "Zsh Installation Hints:" in result.output
+        assert 'eval "$(nadzoring completion zsh)"' in result.output
+        assert "~/.zshrc" in result.output
+        assert "fpath" in result.output
+
+    def test_completion_hints_fish(self, runner):
+        result = runner.invoke(completion_group, ["hints", "fish"])
+
+        assert result.exit_code == 0
+        assert "Fish Installation Hints:" in result.output
+        assert "nadzoring completion fish | source" in result.output
+        assert ".config/fish/completions" in result.output
+
+    def test_completion_hints_powershell(self, runner):
+        result = runner.invoke(completion_group, ["hints", "powershell"])
+
+        assert result.exit_code == 0
+        assert "PowerShell Installation Hints:" in result.output
+        assert "Invoke-Expression" in result.output
+        assert "$PROFILE" in result.output
+
+    def test_completion_hints_invalid_shell(self, runner):
+        result = runner.invoke(completion_group, ["hints", "invalid"])
+
+        assert result.exit_code == 2
+        assert "Invalid value" in result.output or "Error:" in result.output
+
+    def test_completion_hints_help_message(self, runner):
+        result = runner.invoke(completion_group, ["hints", "--help"])
+
+        assert result.exit_code == 0
+        assert "Display installation hints" in result.output
+
+
+class TestIntegration:
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    def test_complete_flow_bash(self, runner):
+        with patch("nadzoring.commands.completions_commands._get_root_cli_and_prog_name") as mock_get:
+            mock_cli = click.Group(name="nadzoring")
+            mock_get.return_value = (mock_cli, "nadzoring")
+
+            result = runner.invoke(completion_group, ["bash"])
+            assert result.exit_code == 0
+
+            with runner.isolated_filesystem():
+                pathlib.Path("completion.bash").write_text(result.output)
+
+                with pathlib.Path("completion.bash").open() as f:
+                    content = f.read()
+                    assert "_NADZORING_COMPLETE" in content
+                    assert "complete" in content
+                    assert "nadzoring" in content
+
+    def test_complete_flow_powershell(self, runner):
+        with patch("nadzoring.commands.completions_commands._get_root_cli_and_prog_name") as mock_get:
+            mock_cli = click.Group(name="nadzoring")
+            mock_get.return_value = (mock_cli, "nadzoring")
+
+            result = runner.invoke(completion_group, ["powershell"])
+            assert result.exit_code == 0
+
+            assert "Register-ArgumentCompleter" in result.output
+            assert "CommandName nadzoring" in result.output
+
+    def test_multiple_completion_calls_independent(self, runner):
+        with patch("nadzoring.commands.completions_commands._get_root_cli_and_prog_name") as mock_get:
+            mock_cli = click.Group(name="nadzoring")
+            mock_get.return_value = (mock_cli, "nadzoring")
+
+            result1 = runner.invoke(completion_group, ["bash"])
+            result2 = runner.invoke(completion_group, ["zsh"])
+
+            assert result1.exit_code == 0
+            assert result2.exit_code == 0
+            assert result1.output != result2.output
+            assert "bash_complete" in result1.output
+            assert "zsh_complete" in result2.output
+
+    def test_completion_group_help(self, runner):
+        result = runner.invoke(completion_group, ["--help"])
+
+        assert result.exit_code == 0
+        assert "Generate shell completion scripts" in result.output
+        assert "bash" in result.output
+        assert "zsh" in result.output
+        assert "fish" in result.output
+        assert "powershell" in result.output
+        assert "hints" in result.output

--- a/tests/test_commands/test_completions.py
+++ b/tests/test_commands/test_completions.py
@@ -38,6 +38,87 @@ class TestPowerShellComplete:
         completer = PowerShellComplete(cli=MagicMock(), ctx_args={}, prog_name="", complete_var="TEST_VAR")
         assert completer.func_name == ""
 
+    def test_get_completion_args_basic(self):
+        completer = PowerShellComplete(
+            cli=MagicMock(),
+            ctx_args={},
+            prog_name="test",
+            complete_var="TEST_VAR",
+        )
+        with patch.dict("os.environ", {"COMP_WORDS": "test command --flag value", "COMP_CWORD": "3"}):
+            args, incomplete = completer.get_completion_args()
+            assert args == ["command", "--flag"]
+            assert incomplete == "value"
+
+    def test_get_completion_args_incomplete_word(self):
+        completer = PowerShellComplete(
+            cli=MagicMock(),
+            ctx_args={},
+            prog_name="test",
+            complete_var="TEST_VAR",
+        )
+        with patch.dict("os.environ", {"COMP_WORDS": "test command --flag val", "COMP_CWORD": "4"}):
+            args, incomplete = completer.get_completion_args()
+            assert args == ["command", "--flag", "val"]
+            assert incomplete == ""
+
+    def test_get_completion_args_empty(self):
+        completer = (
+            PowerShellComplete(
+                cli=MagicMock(),
+                ctx_args={},
+                prog_name="test",
+                complete_var="TEST_VAR",
+            ),
+            {},
+        )
+        with patch.dict("os.environ", {"COMP_WORDS": "test", "COMP_CWORD": "1"}):
+            completer = PowerShellComplete(
+                cli=MagicMock(),
+                ctx_args={},
+                prog_name="test",
+                complete_var="TEST_VAR",
+            )
+            args, incomplete = completer.get_completion_args()
+            assert args == []
+            assert incomplete == ""
+
+    def test_get_completion_args_missing_env_vars(self):
+        completer = PowerShellComplete(
+            cli=MagicMock(),
+            ctx_args={},
+            prog_name="test",
+            complete_var="TEST_VAR",
+        )
+        with patch.dict("os.environ", {}, clear=True):
+            args, incomplete = completer.get_completion_args()
+            assert args == []
+            assert incomplete == ""
+
+    def test_format_completion_plain(self):
+        completer = PowerShellComplete(
+            cli=MagicMock(),
+            ctx_args={},
+            prog_name="test",
+            complete_var="TEST_VAR",
+        )
+        from click.shell_completion import CompletionItem
+
+        item = CompletionItem("test_value", type="plain")
+        assert completer.format_completion(item) == "plain,test_value"
+
+    def test_format_completion_other_types(self):
+        completer = PowerShellComplete(
+            cli=MagicMock(),
+            ctx_args={},
+            prog_name="test",
+            complete_var="TEST_VAR",
+        )
+        from click.shell_completion import CompletionItem
+
+        item = CompletionItem("flag_value", type="flag")
+        assert completer.format_completion(item) == "flag,flag_value"
+
 
 class TestGetRootCliAndProgName:
     def test_single_level_context(self):


### PR DESCRIPTION
This PR fix issue #47.

Add `completion` command group for generating shell completions.

```
Usage: nadzoring completion [OPTIONS] COMMAND [ARGS]...

  Generate shell completion scripts for various shells.

  Each subcommand outputs a shell-specific completion script that can be
  sourced or saved to enable tab-completion for the nadzoring CLI.

Options:
  --help  Show this message and exit.

Commands:
  bash        Generate bash completion script.
  fish        Generate fish completion script.
  hints       Display installation hints for the specified shell.
  powershell  Generate PowerShell completion script.
  zsh         Generate zsh completion script.
```

#### Bash

Add to `~/.bashrc` (or `~/.bash_profile` on macOS):

```bash
echo 'eval "$(nadzoring completion bash)"' >> ~/.bashrc
source ~/.bashrc
```

Alternative — save to a file and source it:

```bash
nadzoring completion bash > ~/.nadzoring-complete.bash
echo 'source ~/.nadzoring-complete.bash' >> ~/.bashrc
```

#### Zsh

Add to `~/.zshrc`:

```bash
echo 'eval "$(nadzoring completion zsh)"' >> ~/.zshrc
source ~/.zshrc
```

Or save to a file in your `fpath`:

```bash
nadzoring completion zsh > "${fpath[1]}/_nadzoring"
```

#### Fish

Save directly to Fish completions directory:

```bash
nadzoring completion fish > ~/.config/fish/completions/nadzoring.fish
```

Or source it temporarily:

```bash
nadzoring completion fish | source
```

#### PowerShell

Add to your PowerShell profile (`$PROFILE`):

```powershell
nadzoring completion powershell >> $PROFILE
```

To reload the profile immediately:

```powershell
. $PROFILE
```

Or use it in the current session only:

```powershell
nadzoring completion powershell | Invoke-Expression
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/alexeev-prog/nadzoring/pull/89" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
